### PR TITLE
Fix result status constant

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -33,6 +33,7 @@ const cs = {
         RUNNING: "RUNNING",
         FAILURE: "FAILURE",
         QUEUED: "QUEUED",
+        NOTBUILDS: "NOTBUILDS",
     },
     command: {
         GET_BUILD: 'getBuild',


### PR DESCRIPTION
## Summary
- define `NOTBUILDS` status so it's not undefined

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68457a04c2d0832cb93190087a00634e