### PR TITLE
[codex] prepare 3.0.0 release cycle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,161 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run checks
+        run: npm test
+
+      - name: Read extension version
+        id: version
+        run: |
+          VERSION="$(node -p "require('./manifest.json').version")"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate package version
+        run: |
+          MANIFEST_VERSION="$(node -p "require('./manifest.json').version")"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$MANIFEST_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "manifest.json version ($MANIFEST_VERSION) does not match package.json version ($PACKAGE_VERSION)."
+            exit 1
+          fi
+
+      - name: Check existing release
+        id: release_exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Stop when version is already released
+        if: steps.release_exists.outputs.exists == 'true'
+        run: echo "Release ${{ steps.version.outputs.tag }} already exists. Nothing to publish."
+
+      - name: Build extension archive
+        if: steps.release_exists.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          DIST_DIR="dist/TeamCity-Pull-Request-Builder-${VERSION}"
+          ARCHIVE="TeamCity-Pull-Request-Builder-${VERSION}.zip"
+
+          rm -rf dist
+          mkdir -p "$DIST_DIR"
+
+          cp -R assets "$DIST_DIR/assets"
+          cp \
+            background.js \
+            bulma.min.css \
+            content-style.css \
+            contentScript.js \
+            LICENSE \
+            manifest.json \
+            options-style.css \
+            options.html \
+            options.js \
+            package.json \
+            package-lock.json \
+            popup.html \
+            popup.js \
+            PrivacyPolicy.md \
+            README.md \
+            style.css \
+            tc-utils.js \
+            "$DIST_DIR/"
+
+          (cd dist && zip -r "$ARCHIVE" "TeamCity-Pull-Request-Builder-${VERSION}")
+          echo "ARCHIVE=dist/$ARCHIVE" >> "$GITHUB_ENV"
+
+      - name: Get Chrome Web Store access token
+        if: steps.release_exists.outputs.exists == 'false'
+        env:
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          TOKEN_RESPONSE="$(curl -sS https://oauth2.googleapis.com/token \
+            -d "client_id=${CHROME_CLIENT_ID}" \
+            -d "client_secret=${CHROME_CLIENT_SECRET}" \
+            -d "refresh_token=${CHROME_REFRESH_TOKEN}" \
+            -d "grant_type=refresh_token")"
+
+          ACCESS_TOKEN="$(node -e "const response = JSON.parse(process.argv[1]); if (!response.access_token) { console.error(JSON.stringify(response, null, 2)); process.exit(1); } console.log(response.access_token);" "$TOKEN_RESPONSE")"
+          echo "::add-mask::$ACCESS_TOKEN"
+          echo "CHROME_ACCESS_TOKEN=$ACCESS_TOKEN" >> "$GITHUB_ENV"
+
+      - name: Upload package to Chrome Web Store
+        if: steps.release_exists.outputs.exists == 'false'
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+        run: |
+          set -euo pipefail
+
+          UPLOAD_RESPONSE="$(curl -sS -X POST \
+            -H "Authorization: Bearer ${CHROME_ACCESS_TOKEN}" \
+            -H "Content-Type: application/zip" \
+            --data-binary "@${ARCHIVE}" \
+            "https://chromewebstore.googleapis.com/upload/v2/publishers/${CHROME_PUBLISHER_ID}/items/${CHROME_EXTENSION_ID}:upload")"
+
+          echo "$UPLOAD_RESPONSE" > chrome-upload-response.json
+          node -e "const response = require('./chrome-upload-response.json'); if (response.uploadState && response.uploadState !== 'SUCCESS') { console.error(JSON.stringify(response, null, 2)); process.exit(1); } if (response.error) { console.error(JSON.stringify(response, null, 2)); process.exit(1); }"
+
+      - name: Publish package to Chrome Web Store
+        if: steps.release_exists.outputs.exists == 'false'
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+        run: |
+          set -euo pipefail
+
+          PUBLISH_RESPONSE="$(curl -sS -X POST \
+            -H "Authorization: Bearer ${CHROME_ACCESS_TOKEN}" \
+            "https://chromewebstore.googleapis.com/v2/publishers/${CHROME_PUBLISHER_ID}/items/${CHROME_EXTENSION_ID}:publish")"
+
+          echo "$PUBLISH_RESPONSE" > chrome-publish-response.json
+          node -e "const response = require('./chrome-publish-response.json'); if (response.error) { console.error(JSON.stringify(response, null, 2)); process.exit(1); }"
+
+      - name: Publish GitHub release
+        if: steps.release_exists.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release create "$TAG" "$ARCHIVE" \
+            --title "$VERSION" \
+            --notes "Automated release for version $VERSION."

--- a/PrivacyPolicy.md
+++ b/PrivacyPolicy.md
@@ -2,19 +2,23 @@
 
 ## 1. Collection and use of information
 
-We may collect and use the following information when you use our Chrome extension:
+The extension does not collect analytics, usage telemetry, session duration, or browser/device information.
 
-- Information about your browser and operating system, including browser version and device type;
-- Information about how you use our extension, including the time and date of use, session duration, and actions you perform within the extension;
+The extension stores configuration locally in Chrome extension storage:
 
-We use this information to improve our extension and optimize its performance for you.
+- TeamCity base URL;
+- TeamCity username;
+- TeamCity password or token;
+- repository and build configuration;
+- optional UI preferences.
+
+This information is used only to show and run TeamCity builds from supported pull request pages.
 
 ## 2. Sharing of information
 
-We do not sell, rent, or disclose your personal information to third parties, except in the following cases:
+We do not sell, rent, or disclose your information to third parties. The extension sends requests only to the configured TeamCity server and runs on the configured GitLab pages declared by the extension permissions.
 
-- If we obtain your permission to share information;
-- If we are required to provide information in accordance with the law or a request from law enforcement.
+Your TeamCity credentials are sent to your configured TeamCity server for authentication.
 
 ## 3. Security
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,20 @@
 ## Description
 The TeamCity-Pull-Request-Builder is a Google Chrome plugin that allows you to automatically trigger builds of your project that are associated with a specific pull request.
 
+## What's new in 3.0.0
+- Better TeamCity status handling, including failed starts and `Unable to collect changes` errors.
+- Refresh build statuses without reloading the merge request page.
+- Build duration display for running and finished builds.
+- Updated GitLab sidebar UI with compact status badges.
+- User-friendly Options page with a visual editor and JSON import/export.
+- Basic test coverage for status, date, duration, and GitLab URL parsing.
+
 ## Installation
 1. Navigate to the TeamCity-Pull-Request-Builder plugin page on the Chrome Web Store using this [link](https://chrome.google.com/webstore/detail/teamcity-pull-request-bui/jeddilgijkpgnncoolllmmjcaplpeijj).
 2. Click the "Add to Chrome" button and confirm the extension installation.
 
 ## Configuration
-The plugin is configured through the Options page by editing a JSON configuration.
+The plugin is configured through the Options page. You can use the visual editor or edit/import the JSON configuration directly.
 
 Example settings:
 ```json
@@ -20,13 +28,14 @@ Example settings:
         "MyRepo": [
             {
                 "BuildType": "Build_Type",
-                "Name": "Build",
+                "Name": "Build"
             },            
             {
                 "BuildType": "Tests_0",
                 "Name": "Tests 0",
                 "Group": "Tests",
                 "Order": 1,
+                "BranchPrefix": "requests",
                 "Depends": "Build_Type"
             },
             {
@@ -37,7 +46,8 @@ Example settings:
                 "Depends": "Build_Type"
             }
         ]
-    }
+    },
+    "HeadingBorder": true
 }
 ```
 
@@ -52,10 +62,37 @@ Each build configuration object contains the following properties:
 - `Name`: The name that will be displayed in the plugin interface.
 - `Group`: The group to which this build configuration belongs. If specified, the build configurations will be grouped under this name in the plugin interface.
 - `Order`: The sequential number to determine the display order of the build configurations within a group.
+- `BranchPrefix`: An optional branch prefix used by TeamCity. Default value: `requests`.
 - `Depends`: An optional identifier of another build type that this configuration depends on. If specified, this build configuration is considered outdated or not actual if the build it depends on has a different version.
+- `HeadingBorder`: Optional boolean. If `true`, headings in the merge request description are rendered with a bottom border for readability.
 
 ## Usage
-After configuring the plugin, builds for pull requests will automatically be triggered according to your configuration.
+After configuring the plugin, open a GitLab merge request. The TeamCity block appears in the right sidebar and shows configured builds, status, duration, and a Run button. Use the refresh button in the block to update statuses without reloading the page.
+
+## Development
+Run the checks and unit tests:
+
+```bash
+npm test
+```
+
+## Release cycle
+Releases are published by GitHub Actions after changes are pushed to `main`.
+
+1. Update the version in `manifest.json` and `package.json`.
+2. Commit and merge the changes into `main`.
+3. The release workflow runs tests, reads the version from `manifest.json`, and checks whether a GitHub release with that tag already exists.
+4. If the release does not exist, the workflow builds the extension zip, uploads it to the Chrome Web Store, submits it for publishing, and creates a GitHub release.
+
+Release tags use the plain version value, for example `3.0.0`.
+
+The workflow expects these GitHub Actions secrets:
+
+- `CHROME_EXTENSION_ID`
+- `CHROME_PUBLISHER_ID`
+- `CHROME_CLIENT_ID`
+- `CHROME_CLIENT_SECRET`
+- `CHROME_REFRESH_TOKEN`
 
 ## Support
 If you encounter any issues using the plugin or have suggestions for its improvement, please create an issue in this repository.

--- a/background.js
+++ b/background.js
@@ -1,3 +1,7 @@
+import "./tc-utils.js";
+
+const utils = globalThis.TcPrbUtils;
+
 const global = {
     COMMAND: {
         GET_BUILD: 'getBuild',
@@ -10,41 +14,50 @@ const global = {
     },
     initListener: async () => {
         chrome.tabs.onUpdated.addListener((tabId, tab) => {
-            const repositories = Object.keys(options.config.Repository);
+            const repositories = Object.keys(options.config?.Repository || {});
+            if (repositories.length === 0) {
+                return;
+            }
             if (tab.url && checkUrlIncludesRepo(tab.url, repositories)) {
                 chrome.tabs.sendMessage(tabId, {
                     type: "OPEN_PULL"
-                });
+                }, () => void chrome.runtime.lastError);
             }
         });
 
         chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+            const reply = promise => {
+                promise
+                    .then(data => {
+                        sendResponse({ response: data });
+                    })
+                    .catch(error => {
+                        console.error(error);
+                        sendResponse({
+                            response: {
+                                isAuthorized: true,
+                                data: null,
+                                error: error.message || String(error)
+                            }
+                        });
+                    });
+            };
+
             if (message.command === global.COMMAND.GET_BUILD) {
-                API.getBuilds(message)
-                    .then(data => {
-                        sendResponse({ response: data });
-                    });
+                reply(API.getBuilds(message));
             } else if (message.command === global.COMMAND.RUN_BUILD) {
-                API.runBuildQueue(message)
-                    .then(data => {
-                        sendResponse({ response: data });
-                    });
+                reply(API.runBuildQueue(message));
             } else if (message.command === global.COMMAND.RELOAD_CONFIG) {
-                options.reloadConfig().then(data => {
-                    sendResponse({ response: data });
-                });
+                reply(options.reloadConfig());
+            } else {
+                sendResponse({ response: null });
             }
             return true;
         });
 
         function checkUrlIncludesRepo(url, repoList) {
-            for (const repo of repoList) {
-                const regex = new RegExp(`gitlab\\.pravo\\.tech\\/.*?\\/${repo}\\/-\\/merge_requests\\/`);
-                if (regex.test(url)) {
-                    return true;
-                }
-            }
-            return false;
+            const repoName = utils.getRepoNameFromGitLabUrl(url);
+            return repoList.includes(repoName);
         }
     }
 }
@@ -56,7 +69,7 @@ const options = {
     },
     getConfig: async () => {
         const { config } = await chrome.storage.local.get(["config"]);
-        return config;
+        return config || {};
     },
     loadConfig: async () => {
         try {
@@ -72,9 +85,9 @@ const options = {
         await options.loadConfig();
     },
     findBranchPrefix: (buildType) => {
-        const data = options.config;
+        const data = options.config || {};
         const defaultValue = 'requests';
-        for (const repoName in data.Repository) {
+        for (const repoName in data.Repository || {}) {
             const builds = data.Repository[repoName];
             for (const build of builds) {
                 if (build.BuildType === buildType) {
@@ -89,6 +102,13 @@ const options = {
 const API = {
     getCredentials: () => {
         return 'Basic ' + btoa(`${options.config.Username}:${options.config.Password}`);
+    },
+    parseResponseData: async (response) => {
+        const contentType = response.headers.get("content-type");
+        if (contentType && contentType.indexOf("application/json") !== -1) {
+            return await response.json();
+        }
+        return await response.text();
     },
     isUnauthorized: (response) => {
         return response.status === 401 && response.ok == false;
@@ -113,7 +133,9 @@ const API = {
             return buildQueue;
         }
         const branchPrefix = options.findBranchPrefix(request.buildType);
-        const url = `${options.config.BaseUrl}app/rest/builds?locator=buildType:${request.buildType},branch:${branchPrefix}/${request.pull},count:1,running:any`;
+        const locator = `buildType:${request.buildType},branch:${branchPrefix}/${request.pull},count:1,running:any`;
+        const fields = "count,build(id,status,state,branchName,webUrl,number,startDate,finishDate,finishOnAgentDate,queuedDate,statusText)";
+        const url = `${options.config.BaseUrl}app/rest/builds?${new URLSearchParams({ locator, fields })}`;
         const response = await fetch(url, {
             headers: {
                 'Authorization': API.getCredentials(),
@@ -127,20 +149,16 @@ const API = {
                 data: null
             };
         }
-        let data = null;
-        const contentType = response.headers.get("content-type");
-        if (contentType && contentType.indexOf("application/json") !== -1) {
-            data = await response.json();
-        } else {
-            data = await response.text();
-        }
+        let data = await API.parseResponseData(response);
         return {
             isAuthorized: isAuthorized,
             data: isAuthorized ? data : null
         };
     },
     getBuildQueue: async (request) => {
-        const url = `${options.config.BaseUrl}app/rest/buildQueue?locator=buildType:(id:${request.buildType})`;
+        const locator = `buildType:(id:${request.buildType})`;
+        const fields = "count,build(id,status,state,branchName,webUrl,number,startDate,finishDate,finishOnAgentDate,queuedDate,statusText)";
+        const url = `${options.config.BaseUrl}app/rest/buildQueue?${new URLSearchParams({ locator, fields })}`;
         const response = await fetch(url, {
             headers: {
                 'Authorization': API.getCredentials(),
@@ -156,14 +174,11 @@ const API = {
             };
         }
         let data = null;
-        const contentType = response.headers.get("content-type");
         const branchPrefix = options.findBranchPrefix(request.buildType);
-        if (contentType && contentType.indexOf("application/json") !== -1) {
-            data = await response.json();
-            data.build = data.build.filter(item => item.branchName === `${branchPrefix}/${request.pull}`);
+        data = await API.parseResponseData(response);
+        if (typeof data === "object" && data !== null) {
+            data.build = utils.getBuilds(data).filter(item => item.branchName === `${branchPrefix}/${request.pull}`);
             data.count = data.build.length;
-        } else {
-            data = await response.text();
         }
         return {
             isAuthorized: isAuthorized,
@@ -193,9 +208,10 @@ const API = {
         if (!response.ok) {
             throw new Error(response.statusText);
         }
+        const data = !response.redirected ? await API.parseResponseData(response) : null;
         return {
             isAuthorized: !response.redirected,
-            data: !response.redirected ? await response.json() : null
+            data
         };
     },
     logout: async () => {

--- a/content-style.css
+++ b/content-style.css
@@ -1,0 +1,256 @@
+#root-build-tc-menu.tc-panel {
+    border-top: 0;
+    box-shadow: none;
+    padding-top: 8px;
+}
+
+.tc-panel-header {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.tc-panel-title {
+    color: #333238;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 20px;
+}
+
+.tc-refresh-button {
+    align-items: center;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    color: #737278;
+    cursor: pointer;
+    display: inline-flex;
+    height: 26px;
+    justify-content: center;
+    padding: 0;
+    width: 26px;
+}
+
+.tc-refresh-button:hover {
+    background: #ececef;
+    border-color: transparent;
+    color: #333238;
+}
+
+.tc-refresh-button[disabled] {
+    cursor: wait;
+    opacity: .65;
+}
+
+.tc-refresh-icon {
+    fill: currentColor;
+    height: 15px;
+    width: 15px;
+}
+
+.tc-build-list {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+}
+
+.tc-group {
+    margin-top: 2px;
+}
+
+.tc-group-title {
+    align-items: center;
+    color: #737278;
+    display: flex;
+    font-size: 11px;
+    font-weight: 600;
+    gap: 7px;
+    line-height: 14px;
+    margin: 7px 0 3px;
+    text-transform: uppercase;
+}
+
+.tc-group-title::before,
+.tc-group-title::after {
+    background: #dcdcde;
+    content: "";
+    flex: 1;
+    height: 1px;
+}
+
+.tc-build-row {
+    align-items: center;
+    border-radius: 4px;
+    display: grid;
+    gap: 7px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    min-height: 42px;
+    margin: 0 -4px;
+    padding: 2px 4px;
+}
+
+.tc-build-row:hover {
+    background: #f7f7f8;
+}
+
+.tc-build-row:hover .tc-build-button {
+    color: #535158;
+}
+
+.tc-build-main {
+    min-width: 0;
+}
+
+.tc-build-name {
+    color: #333238;
+    display: block;
+    font-size: 13.5px;
+    line-height: 18px;
+    overflow: hidden;
+    text-decoration: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tc-build-name:hover {
+    color: #1f75cb;
+    text-decoration: underline;
+}
+
+.tc-build-meta {
+    align-items: center;
+    color: #737278;
+    display: flex;
+    flex-wrap: nowrap;
+    font-size: 12.5px;
+    gap: 5px;
+    line-height: 17px;
+    margin-top: 0;
+    min-width: 0;
+}
+
+.tc-build-meta span:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tc-status {
+    align-items: center;
+    display: inline-flex;
+    flex: 0 0 auto;
+    height: 17px;
+    justify-content: center;
+    width: 17px;
+}
+
+.tc-status-icon {
+    fill: currentColor;
+    height: 15px;
+    width: 15px;
+}
+
+.tc-status-success {
+    color: #217645;
+}
+
+.tc-status-failure {
+    color: #c91c00;
+}
+
+.tc-status-running {
+    color: #9e5400;
+}
+
+.tc-status-queued {
+    color: #535158;
+}
+
+.tc-status-muted {
+    color: #737278;
+}
+
+.tc-outdated {
+    align-items: center;
+    color: #9e5400;
+    display: inline-flex;
+    flex: 0 0 auto;
+    height: 17px;
+    justify-content: center;
+    width: 17px;
+}
+
+.tc-build-button {
+    align-items: center;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    color: #737278;
+    cursor: pointer;
+    display: inline-flex;
+    font-size: 13px;
+    height: 28px;
+    justify-content: center;
+    line-height: 18px;
+    padding: 0;
+    width: 30px;
+}
+
+.tc-run-icon {
+    fill: currentColor;
+    height: 14px;
+    width: 14px;
+}
+
+.tc-build-button:hover {
+    background: #ececef;
+    border-color: transparent;
+    color: #333238;
+}
+
+.tc-refresh-button:focus-visible,
+.tc-build-button:focus-visible {
+    border-color: #1f75cb;
+    box-shadow: 0 0 0 2px rgba(31, 117, 203, .18);
+    outline: none;
+}
+
+.tc-build-button[disabled] {
+    cursor: wait;
+    opacity: .7;
+}
+
+.tc-build-button-busy {
+    color: #535158;
+    font-weight: 600;
+}
+
+.tc-build-button-error {
+    color: #c91c00;
+    font-weight: 700;
+}
+
+.tc-panel-message {
+    border-radius: 4px;
+    font-size: 13px;
+    line-height: 18px;
+    padding: 8px;
+}
+
+.tc-panel-message-danger {
+    background: #fbe9eb;
+    color: #c91c00;
+}
+
+.tc-panel-message-muted {
+    background: #f7f7f8;
+    color: #737278;
+}
+
+.tc-loader {
+    color: #737278;
+    font-size: 13px;
+    padding: 8px 0;
+}

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,3 +1,5 @@
+const utils = globalThis.TcPrbUtils;
+
 const options = {
     config: {},
     init: async () => {
@@ -5,49 +7,40 @@ const options = {
     },
     getConfig: async () => {
         const { config } = await chrome.storage.local.get(["config"]);
-        return config;
+        return config || {};
     },
     loadConfig: async () => {
         try {
-            let config = await options.getConfig();
-            options.config = config;
-        }
-        catch (err) {
+            options.config = await options.getConfig();
+        } catch (err) {
+            options.config = {};
             console.error(err);
         }
     },
     validConfig: async () => {
         const requiredFields = ["BaseUrl", "Username", "Password", "Repository"];
-        for (const field of requiredFields) {
-            if (!options.config.hasOwnProperty(field)) {
-                return false;
-            }
+        if (!options.config || typeof options.config !== "object") {
+            return false;
         }
-        return true;
+        return requiredFields.every(field => Object.prototype.hasOwnProperty.call(options.config, field));
     }
 };
 
 const cs = {
-    resultStatus: {
-        SUCCESS: "SUCCESS",
-        RUNNING: "RUNNING",
-        FAILURE: "FAILURE",
-        QUEUED: "QUEUED",
-    },
     command: {
-        GET_BUILD: 'getBuild',
-        RUN_BUILD: 'runBuild',
-        RELOAD_CONFIG: 'reloadConfig'
+        GET_BUILD: "getBuild",
+        RUN_BUILD: "runBuild",
+        RELOAD_CONFIG: "reloadConfig"
     },
     init: async () => {
         await options.init();
 
-        window.addEventListener('load', async () => {
+        window.addEventListener("load", async () => {
             await cs.render();
         });
 
         chrome.runtime.onMessage.addListener(({ type }) => {
-            if (type === 'OPEN_PULL') {
+            if (type === "OPEN_PULL") {
                 setTimeout(async () => await cs.render(), 1000);
             }
         });
@@ -57,305 +50,326 @@ const cs = {
         addHeadingBorderInMergeRequestDescription();
     },
     getRepoBuildSetting: () => {
-        function getRepoName() {
-            const regex = /https:\/\/gitlab\.pravo\.tech\/[^/]+\/([^/]+)/;
-            const match = window.location.href.match(regex);
-            if (match && match[1]) {
-                return match[1];
-            }
-        };
-        function findRepoInSetting() {
-            const repoName = getRepoName();
-            const jsonData = options.config;
-            if (jsonData.Repository && jsonData.Repository[repoName]) {
-                return jsonData.Repository[repoName];
-            }
-            return;
-        };
-        return findRepoInSetting();
+        const repoName = utils.getRepoNameFromGitLabUrl(window.location.href);
+        const repositories = options.config?.Repository || {};
+        return repositories[repoName];
     }
-}
+};
 
 function getPullNumber() {
-    const bodyElement = document.querySelector('body');
-    const pageTypeId = bodyElement.getAttribute('data-page-type-id');
-    return parseInt(pageTypeId);
+    const bodyElement = document.querySelector("body");
+    const pageTypeId = bodyElement?.getAttribute("data-page-type-id");
+    const fromPageType = Number.parseInt(pageTypeId, 10);
+    if (Number.isFinite(fromPageType)) {
+        return fromPageType;
+    }
+
+    const match = window.location.href.match(/\/merge_requests\/(\d+)/);
+    return match ? Number.parseInt(match[1], 10) : null;
 }
 
 function createSidebarItem() {
     let sidebarItem = document.getElementById("root-build-tc-menu");
-    if (sidebarItem) {
-        sidebarItem.innerHTML = "";
-    } else {
+    if (!sidebarItem) {
         sidebarItem = document.createElement("div");
         sidebarItem.setAttribute("id", "root-build-tc-menu");
-        sidebarItem.classList.add("block", "build-tc");
     }
+
+    sidebarItem.className = "block build-tc tc-panel";
+    sidebarItem.replaceChildren();
     return sidebarItem;
 }
 
-function createDetailsElement() {
-    const detailsElement = document.createElement("div");
-    detailsElement.classList.add("gl--flex-full", "gl-align-items-center", "gl-display-flex", "gl-font-weight-bold", "gl-line-height-20", "gl-text-gray-900");
-    detailsElement.setAttribute("id", "labels-select-menu");
-    return detailsElement;
+function createRefreshIcon() {
+    return createSvgIcon("M1.5 8a6.5 6.5 0 0 1 11.1-4.6V1.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-.75.75h-3.5a.75.75 0 0 1 0-1.5h1.67A5 5 0 1 0 13 8a.75.75 0 0 1 1.5 0A6.5 6.5 0 1 1 1.5 8Z", "tc-refresh-icon");
 }
 
-function createSummaryElement() {
-    const element = document.createElement("span");
-    element.textContent = "Build in TeamCity";
-    return element;
+function createSvgIcon(pathData, className) {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("viewBox", "0 0 16 16");
+    svg.setAttribute("aria-hidden", "true");
+    svg.classList.add(className);
+
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", pathData);
+    svg.appendChild(path);
+    return svg;
 }
 
-function appendErrorElement(labelsElement, id, errorText, actionText, className) {
-    if (!document.getElementById(id)) {
-        const label = document.createElement("p");
-        label.classList.add("mt-2");
-        label.innerHTML = `
-            <span class="d-flex min-width-0 flex-1 js-hovercard-left" id="${id}">
-              <div class="${className} assignee text-center" style="width: 100%;">
-              <div>${errorText}</div>
-                <div class="vertical-align-sub">${actionText}</div>
-              </div>
-            </span>`;
-        labelsElement.appendChild(label);
-    }
+function createHeaderElement(builds, labelsElement) {
+    const header = document.createElement("div");
+    header.classList.add("tc-panel-header");
+
+    const title = document.createElement("div");
+    title.classList.add("tc-panel-title");
+    title.textContent = "Build in TeamCity";
+
+    const refreshButton = document.createElement("button");
+    refreshButton.type = "button";
+    refreshButton.classList.add("tc-refresh-button");
+    refreshButton.title = "Refresh statuses";
+    refreshButton.appendChild(createRefreshIcon());
+    refreshButton.addEventListener("click", async () => {
+        refreshButton.disabled = true;
+        await refreshBuildLabels(labelsElement, builds);
+        refreshButton.disabled = false;
+    });
+
+    header.appendChild(title);
+    header.appendChild(refreshButton);
+    return header;
+}
+
+function appendMessage(container, message, type = "muted") {
+    const element = document.createElement("div");
+    element.classList.add("tc-panel-message", `tc-panel-message-${type}`);
+    element.textContent = message;
+    container.appendChild(element);
 }
 
 function createLoaderElement() {
     const loaderElement = document.createElement("div");
-    loaderElement.setAttribute("id", "tc-loader");
-    loaderElement.classList.add("text-center");
-    const loaderHTML = `
-    <div class="text-center">
-        <span aria-label="Loading" role="status" class="gl-spinner-container align-bottom">
-            <span class="gl-spinner gl-spinner-lg !gl-vertical-align-text-bottom gl-spinner-dark mt-2"></span>
-        </span>
-    </div>
-  `;
-    loaderElement.innerHTML = loaderHTML;
+    loaderElement.classList.add("tc-loader");
+    loaderElement.textContent = "Loading TeamCity builds...";
     return loaderElement;
 }
 
 async function fetchBuilds(builds, pull) {
-    const requests = builds.map(data =>
-        new Promise(async (resolve, reject) => {
-            try {
-                const response = await chrome.runtime.sendMessagePromise({
-                    command: cs.command.GET_BUILD,
-                    buildType: data.BuildType,
-                    pull: pull
-                });
-                resolve({ ...data, response });
-            } catch (error) {
-                reject(error);
-            }
-        })
-    );
+    const requests = builds.map(async data => {
+        const response = await chrome.runtime.sendMessagePromise({
+            command: cs.command.GET_BUILD,
+            buildType: data.BuildType,
+            pull
+        });
+        return { ...data, response };
+    });
 
     return await Promise.all(requests);
 }
 
-function createLabelsElement(builds) {
+function sortBuilds(builds) {
+    return [...builds].sort((a, b) => {
+        const defaultGroup = "zzzz";
+        const defaultOrder = Infinity;
+        const groupA = a.Group != null ? a.Group : defaultGroup;
+        const groupB = b.Group != null ? b.Group : defaultGroup;
+        const orderA = a.Order != null ? a.Order : defaultOrder;
+        const orderB = b.Order != null ? b.Order : defaultOrder;
+
+        if (groupA === defaultGroup && groupB !== defaultGroup) {
+            return -1;
+        }
+        if (groupA !== defaultGroup && groupB === defaultGroup) {
+            return 1;
+        }
+        if (groupA !== groupB) {
+            return groupA < groupB ? -1 : 1;
+        }
+        return orderA - orderB;
+    });
+}
+
+function isBuildActual(build, responses) {
+    if (!build.Depends) {
+        return true;
+    }
+
+    const dependsBuild = responses.find(item => item.BuildType === build.Depends);
+    const dependsNumber = utils.getBuilds(dependsBuild?.response?.response?.data)[0]?.number;
+    const currentNumber = utils.getBuilds(build?.response?.response?.data)[0]?.number;
+    if (!dependsNumber || !currentNumber) {
+        return true;
+    }
+
+    const dependsVersion = utils.extractVersionNumber(dependsNumber);
+    const currentVersion = utils.extractVersionNumber(currentNumber);
+    return Boolean(dependsVersion && currentVersion && dependsVersion === currentVersion);
+}
+
+function getStatusIconPath(statusInfo) {
+    switch (statusInfo.status) {
+        case utils.resultStatus.SUCCESS:
+            return "M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z";
+        case utils.resultStatus.FAILURE:
+        case utils.resultStatus.ERROR:
+            return "M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z";
+        case utils.resultStatus.RUNNING:
+            return "M8 1.5a6.5 6.5 0 1 1 0 13 6.5 6.5 0 0 1 0-13Zm0 1.5a5 5 0 1 0 0 10A5 5 0 0 0 8 3Zm.75 2.75v2.1l1.55 1.55a.75.75 0 1 1-1.06 1.06L7.47 8.69A.75.75 0 0 1 7.25 8V5.75a.75.75 0 0 1 1.5 0Z";
+        case utils.resultStatus.QUEUED:
+            return "M4 1.75A.75.75 0 0 1 4.75 1h6.5a.75.75 0 0 1 .75.75v1.1A4.25 4.25 0 0 1 9.46 6.75 4.25 4.25 0 0 1 12 10.65v1.6a.75.75 0 0 1-.75.75h-6.5A.75.75 0 0 1 4 12.25v-1.6a4.25 4.25 0 0 1 2.54-3.9A4.25 4.25 0 0 1 4 2.85v-1.1Zm1.5.75v.35A2.75 2.75 0 0 0 8.25 5.6 2.75 2.75 0 0 0 11 2.85V2.5H5.5Zm0 8.15v.85H11v-.85A2.75 2.75 0 0 0 8.25 7.9 2.75 2.75 0 0 0 5.5 10.65Z";
+        default:
+            return "M8 1.5a6.5 6.5 0 1 1 0 13 6.5 6.5 0 0 1 0-13Zm0 1.5a5 5 0 1 0 0 10A5 5 0 0 0 8 3Z";
+    }
+}
+
+function getBuildMetaText(statusInfo, timing) {
+    if (statusInfo.status === utils.resultStatus.NOT_BUILDS) {
+        return "No builds yet";
+    }
+    if (statusInfo.status === utils.resultStatus.QUEUED) {
+        return "Waiting in queue";
+    }
+    if (statusInfo.status === utils.resultStatus.RUNNING) {
+        return timing.durationText ? `Running for ${timing.durationText}` : "Build in progress";
+    }
+
+    const datePart = timing.dateText ? `Last build: ${timing.dateText}` : "Last build";
+    return timing.durationText ? `${datePart} (${timing.durationText})` : datePart;
+}
+
+function createStatusIcon(statusInfo) {
+    const status = document.createElement("span");
+    status.classList.add("tc-status", `tc-status-${statusInfo.severity}`);
+    status.title = statusInfo.label;
+    status.appendChild(createSvgIcon(getStatusIconPath(statusInfo), "tc-status-icon"));
+    return status;
+}
+
+function createRunIcon() {
+    return createSvgIcon("M4.25 2.75a.75.75 0 0 1 1.12-.65l6.5 4.25a.75.75 0 0 1 0 1.3l-6.5 4.25a.75.75 0 0 1-1.12-.65v-8.5Z", "tc-run-icon");
+}
+
+function setRunButtonState(button, state) {
+    button.replaceChildren();
+    button.classList.remove("tc-build-button-busy", "tc-build-button-error");
+
+    if (state === "starting") {
+        button.textContent = "...";
+        button.title = "Starting build";
+        button.classList.add("tc-build-button-busy");
+        return;
+    }
+    if (state === "queued") {
+        button.appendChild(createSvgIcon(getStatusIconPath({ status: utils.resultStatus.QUEUED }), "tc-run-icon"));
+        button.title = "Build queued";
+        button.classList.add("tc-build-button-busy");
+        return;
+    }
+    if (state === "retry") {
+        button.textContent = "!";
+        button.title = "Build start failed. Retry";
+        button.classList.add("tc-build-button-error");
+        return;
+    }
+
+    button.appendChild(createRunIcon());
+    button.title = "Run build";
+}
+
+function createBuildRow(buildConfig, responses, pull) {
+    const data = buildConfig.response?.response?.data;
+    const build = utils.getBuilds(data)[0];
+    const statusInfo = utils.normalizeBuildStatus(data);
+    const timing = utils.getBuildTiming(build);
+    const buildIsActual = isBuildActual(buildConfig, responses);
+    const defaultHref = `${options.config.BaseUrl}buildConfiguration/${encodeURIComponent(buildConfig.BuildType)}?mode=builds#all-projects`;
+
+    const item = document.createElement("div");
+    item.classList.add("tc-build-row");
+
+    const main = document.createElement("div");
+    main.classList.add("tc-build-main");
+
+    const link = document.createElement("a");
+    link.classList.add("tc-build-name");
+    link.href = build?.webUrl || defaultHref;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.textContent = buildConfig.Name || buildConfig.BuildType;
+    main.appendChild(link);
+
+    const meta = document.createElement("div");
+    meta.classList.add("tc-build-meta");
+
+    const text = document.createElement("span");
+    text.textContent = getBuildMetaText(statusInfo, timing);
+    meta.appendChild(text);
+    meta.appendChild(createStatusIcon(statusInfo));
+
+    if (!buildIsActual) {
+        const outdated = document.createElement("span");
+        outdated.classList.add("tc-outdated");
+        outdated.title = `Depends on ${buildConfig.Depends}`;
+        outdated.appendChild(createSvgIcon("M8.67 1.98a.75.75 0 0 0-1.34 0l-6 11A.75.75 0 0 0 2 14h12a.75.75 0 0 0 .67-1.1l-6-11ZM8.75 6v3.25a.75.75 0 0 1-1.5 0V6a.75.75 0 0 1 1.5 0ZM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z", "tc-status-icon"));
+        meta.appendChild(outdated);
+    }
+
+    main.appendChild(meta);
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.classList.add("tc-build-button");
+    button.setAttribute("aria-label", `Run ${buildConfig.Name || buildConfig.BuildType}`);
+    setRunButtonState(button, "idle");
+    button.addEventListener("click", event => handleBuildButtonClick(event, { BuildType: buildConfig.BuildType, pull }));
+
+    item.appendChild(main);
+    item.appendChild(button);
+    return item;
+}
+
+function appendGroupTitle(container, title) {
+    const groupTitle = document.createElement("div");
+    groupTitle.classList.add("tc-group-title");
+    const label = document.createElement("span");
+    label.textContent = title;
+    groupTitle.appendChild(label);
+    container.appendChild(groupTitle);
+}
+
+function renderBuildResponses(container, responses, pull) {
+    const list = document.createElement("div");
+    list.classList.add("tc-build-list");
+
+    let currentGroup = null;
+    for (const buildConfig of sortBuilds(responses)) {
+        const envelope = buildConfig.response?.response;
+        if (!envelope?.isAuthorized || envelope.data === null) {
+            appendMessage(container, "Failed to connect to TeamCity. Check options and permissions.", "danger");
+            return;
+        }
+
+        if (buildConfig.Group && buildConfig.Group !== currentGroup) {
+            currentGroup = buildConfig.Group;
+            appendGroupTitle(list, buildConfig.Group);
+        }
+        if (!buildConfig.Group) {
+            currentGroup = null;
+        }
+
+        list.appendChild(createBuildRow(buildConfig, responses, pull));
+    }
+
+    container.appendChild(list);
+}
+
+async function refreshBuildLabels(labelsElement, builds) {
+    labelsElement.replaceChildren(createLoaderElement());
+
     const pull = getPullNumber();
+    const isValid = await options.validConfig();
+    if (!isValid || !pull) {
+        labelsElement.replaceChildren();
+        appendMessage(labelsElement, "TeamCity settings are incomplete.", "danger");
+        return;
+    }
+
+    try {
+        const responses = await fetchBuilds(builds, pull);
+        labelsElement.replaceChildren();
+        renderBuildResponses(labelsElement, responses, pull);
+    } catch (error) {
+        console.error("TeamCity request failed:", error);
+        labelsElement.replaceChildren();
+        appendMessage(labelsElement, "Could not load TeamCity builds.", "danger");
+    }
+}
+
+function createLabelsElement(builds) {
     const labelsElement = document.createElement("div");
-    labelsElement.classList.add("flex-wrap");
-    labelsElement.classList.add("sidebar-assignee");
-    const loaderElement = createLoaderElement();
-    labelsElement.appendChild(loaderElement);
-
-    options.validConfig()
-        .then((status) => {
-            if (status) {
-                fetchBuilds(builds, pull)
-                    .then(responses => {
-                        responses.sort((a, b) => {
-                            const defaultGroup = 'zzzz';
-                            const defaultOrder = Infinity;
-
-                            const groupA = a.Group != null ? a.Group : defaultGroup;
-                            const orderA = a.Order != null ? a.Order : defaultOrder;
-                            const groupB = b.Group != null ? b.Group : defaultGroup;
-                            const orderB = b.Order != null ? b.Order : defaultOrder;
-
-                            if (groupA === defaultGroup && groupB === defaultGroup) {
-                                return orderA - orderB;
-                            }
-
-                            if (groupA === defaultGroup || groupB === defaultGroup) {
-                                return groupA === defaultGroup ? -1 : 1;
-                            }
-
-                            if (groupA < groupB) {
-                                return -1;
-                            } else if (groupA > groupB) {
-                                return 1;
-                            } else {
-                                return orderA - orderB;
-                            }
-                        });
-
-                        let currentGroup = null;
-                        let groupElement = null;
-
-                        labelsElement.removeChild(loaderElement);
-                        for (const { response, Name, BuildType, Group, Depends } of responses) {
-                            if (response.response === null || !response.response.isAuthorized) {
-                                appendErrorElement(labelsElement, 'isRequestError', 'Failed to connect to the server', "Please verify connection settings in 'Options' page.", 'text-danger');
-                                return;
-                            }
-                            if (Group != currentGroup) {
-                                currentGroup = Group;
-                                if (Group) {
-                                    groupElement = document.createElement("div");
-                                    groupElement.classList.add("group");
-                                    const groupTitle = createGroupTitle(Group);
-                                    groupElement.appendChild(groupTitle);
-                                    labelsElement.appendChild(groupElement);
-                                }
-                            } else {
-                                groupElement = labelsElement;
-                            }
-                            let buildIsActual = true;
-                            if (Depends) {
-                                const dependsBuild = responses.find(x => x.BuildType === Depends);
-                                if (dependsBuild) {
-                                    const dependsBuildNumber = dependsBuild.response.response.data.build[0]?.number;
-                                    const responseBuildNumber = response.response.data.build[0]?.number;
-                                    if (dependsBuildNumber && responseBuildNumber) {
-                                        const dependsVersion = extractVersionNumber(dependsBuildNumber);
-                                        const responseVersion = extractVersionNumber(responseBuildNumber);
-
-                                        if (!dependsVersion || !responseVersion || dependsVersion !== responseVersion) {
-                                            buildIsActual = false;
-                                        }
-                                    }
-                                }
-                            }
-
-                            const buildResult = checkStatus(response.response.data);
-                            let details = "";
-                            if (buildResult === cs.resultStatus.SUCCESS) {
-                                details = createBuildDetailsElement(
-                                    `Last build: ${formatDate(response.response.data.build[0].finishOnAgentDate)}`,
-                                    createSvgElement("M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z", "text-success"),
-                                    buildIsActual
-                                );
-                            } else if (buildResult === cs.resultStatus.FAILURE) {
-                                const buildText = response.response.data.build[0].finishOnAgentDate
-                                    ? `Last build: ${formatDate(response.response.data.build[0].finishOnAgentDate)}`
-                                    : `Build in progress`;
-                                details = createBuildDetailsElement(buildText,
-                                    createSvgElement("M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z", "text-danger"),
-                                    buildIsActual
-                                );
-                            } else if (buildResult === cs.resultStatus.RUNNING) {
-                                details = createBuildDetailsElement(
-                                    "Build in progress",
-                                    createSvgElement("M8 4a4 4 0 1 1 0 8 4 4 0 0 1 0-8Z", "text-warning"),
-                                    buildIsActual
-                                );
-                            } else if (buildResult === cs.resultStatus.QUEUED) {
-                                details = createBuildDetailsElement(
-                                    "Build in queue",
-                                    createSvgElement("M13 3.07v-2H3v2A5 5 0 0 0 7.65 8 5 5 0 0 0 3 13v2h10v-2a5 5 0 0 0-4.65-5A5 5 0 0 0 13 3.07zm-8.6-.6h7.2v.6a3.67 3.67 0 0 1-.14.93H4.54a3.67 3.67 0 0 1-.14-.93zM11.6 13v.6H4.4V13a3.6 3.6 0 0 1 7.2 0z", "")
-                                );
-                            } else {
-                                details = createBuildDetailsElement("Build not initiated yet");
-                            }
-
-                            const item = document.createElement("div");
-                            item.classList.add("mb-2");
-
-                            const defaultHref = `${options.config.BaseUrl}buildConfiguration/${BuildType}?mode=builds#all-projects`;
-
-                            const label = document.createElement("div");
-                            label.classList.add("Link--primary");
-                            label.classList.add("v-align-middle");
-                            label.innerHTML = `<a class="" href="${response.response.data.count === 0 ? defaultHref : response.response.data.build[0].webUrl}" target="_blank">${Name}</a>`;
-                            item.appendChild(label);
-
-                            const configurations = document.createElement("div");
-                            configurations.classList.add("gl--flex-full");
-                            configurations.classList.add("gl-display-flex");
-                            configurations.classList.add("gl-align-items-center");
-                            configurations.classList.add("gl-line-height-20");
-                            configurations.classList.add("gl-text-gray-900");
-                            configurations.innerHTML = `${details}`;
-                            item.appendChild(configurations);
-
-                            groupElement.appendChild(item);
-                            const button = item.querySelector(".Button");
-                            button.addEventListener("click", (event) => handleBuildButtonClick(event, { BuildType, pull }));
-                        };
-                    })
-                    .catch(error => {
-                        console.error("Ошибка при выполнении запросов:", error);
-                        labelsElement.removeChild(loaderElement);
-                    });
-            }
-            else {
-                labelsElement.removeChild(loaderElement);
-                appendErrorElement(labelsElement, 'isRequestError', 'Failed to connect to the server', "Please verify connection settings in 'Options' page.", 'text-danger');
-            }
-        });
+    labelsElement.classList.add("tc-panel-body");
+    refreshBuildLabels(labelsElement, builds);
     return labelsElement;
-}
-
-function createGroupTitle(title) {
-    let container = document.createElement("div");
-    container.style.display = "flex";
-    container.style.alignItems = "center";
-    container.style.justifyContent = "center";
-    container.style.width = "100%";
-
-    let line1 = document.createElement("span");
-    line1.style.flexGrow = ".15";
-    line1.style.height = "1px";
-    line1.style.background = "#d8dee4";
-    container.appendChild(line1);
-
-    let text = document.createElement("span");
-    text.textContent = title;
-    text.style.margin = "0 10px";
-    text.classList.add("text-bold");
-    text.classList.add("discussion-sidebar-heading");
-    container.appendChild(text);
-
-    let line2 = document.createElement("span");
-    line2.style.flexGrow = "1";
-    line2.style.height = "1px";
-    line2.style.background = "#d8dee4";
-    container.appendChild(line2);
-
-    return container;
-}
-
-function createSvgElement(path, extraClasses) {
-    return `
-      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="vertical-align-sub ${extraClasses}">
-        <path d="${path}"></path>
-      </svg>`;
-}
-
-function createBuildDetailsElement(text, svgElement = '', buildIsActual = true) {
-    const buildIsActualText = buildIsActual ? '' :
-        `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
-        <title>Build is outdated</title>
-        <polygon points="12,1 1,23 23,23" fill="none" stroke="#ab6100"/>
-        <line x1="12" y1="6" x2="12" y2="15" stroke="#ab6100" stroke-width="1.5"/>
-        <circle cx="12" cy="18" r="1" fill="#ab6100" />
-      </svg>`;
-
-    return `
-    <div class="gl-text-gray-500 text-1">
-        ${text}
-        ${svgElement}
-        ${buildIsActualText}
-    </div>
-    <button class="Button Button--link btn gl-ml-auto btn-default btn-sm gl-button">
-        <span class="Button-label gl-button-text text-1">Run</span>
-    </button>`;
 }
 
 function addBuildInTeamCityMenu() {
@@ -364,129 +378,81 @@ function addBuildInTeamCityMenu() {
         return;
     }
 
-    const tryToAddMenu = setInterval(() => {
-        const projectsMenu = document.getElementById('milestone-edit');
-        if (projectsMenu) {
-            clearInterval(tryToAddMenu);
+    if (window.__tcPrbMenuTimer) {
+        clearInterval(window.__tcPrbMenuTimer);
+    }
 
-            const parent = projectsMenu.closest('.milestone');
-            const sidebarItem = createSidebarItem();
-            const detailsElement = createDetailsElement();
-            const summaryElement = createSummaryElement();
-            const labelsElement = createLabelsElement(buildSetting);
-
-            addScrollToForm(parent);
-
-            detailsElement.appendChild(summaryElement);
-            sidebarItem.appendChild(detailsElement);
-            sidebarItem.appendChild(labelsElement);
-            parent.parentNode.insertBefore(sidebarItem, parent);
+    let attempts = 0;
+    window.__tcPrbMenuTimer = setInterval(() => {
+        attempts += 1;
+        const projectsMenu = document.getElementById("milestone-edit");
+        if (!projectsMenu && attempts < 30) {
+            return;
         }
+
+        clearInterval(window.__tcPrbMenuTimer);
+        window.__tcPrbMenuTimer = null;
+        if (!projectsMenu) {
+            return;
+        }
+
+        const parent = projectsMenu.closest(".milestone");
+        if (!parent?.parentNode) {
+            return;
+        }
+
+        const sidebarItem = createSidebarItem();
+        const labelsElement = createLabelsElement(buildSetting);
+
+        addScrollToForm(parent);
+        sidebarItem.appendChild(createHeaderElement(buildSetting, labelsElement));
+        sidebarItem.appendChild(labelsElement);
+        parent.parentNode.insertBefore(sidebarItem, parent);
     }, 500);
 }
 
 function addHeadingBorderInMergeRequestDescription() {
     if (options.config.HeadingBorder === true) {
-        const descriptionElement = document.querySelector('.merge-request-overview .detail-page-description .description.js-task-list-container');
+        const descriptionElement = document.querySelector(".merge-request-overview .detail-page-description .description.js-task-list-container");
         if (descriptionElement) {
-            const headings = descriptionElement.querySelectorAll('h1, h2, h3, h4, h5, h6');
+            const headings = descriptionElement.querySelectorAll("h1, h2, h3, h4, h5, h6");
             headings.forEach(heading => {
-                heading.style.borderBottom = '1px solid rgb(216, 222, 228)';
-                heading.style.paddingBottom = '.3em';
-                heading.style.fontSize = '1.5em';
+                heading.style.borderBottom = "1px solid rgb(216, 222, 228)";
+                heading.style.paddingBottom = ".3em";
+                heading.style.fontSize = "1.5em";
             });
         }
     }
 }
 
 function addScrollToForm(element) {
-    const form = element.closest('form.issuable-context-form');
-    form.style.overflowY = 'auto';
-    form.style.paddingLeft = '0px';
+    const form = element.closest("form.issuable-context-form");
+    if (form) {
+        form.style.overflowY = "auto";
+        form.style.paddingLeft = "0px";
+    }
 }
 
-function handleBuildButtonClick(event, { BuildType, pull }) {
+async function handleBuildButtonClick(event, { BuildType, pull }) {
     event.preventDefault();
-    const button = event.target.closest('.Button--link');
-    if (!button) return;
+    const button = event.currentTarget;
     button.disabled = true;
-    button.querySelector('.Button-label').textContent = 'Started';
-    chrome.runtime.sendMessage({
-        command: cs.command.RUN_BUILD,
-        buildType: BuildType,
-        pull: pull
-    }, function (response) {
-        if (response.state === "queued") {
-            button.querySelector('.Button-label').textContent = 'In queue';
-        }
-    });
-}
+    setRunButtonState(button, "starting");
 
-function formatDate(inputDate) {
     try {
-        const year = inputDate.slice(0, 4);
-        const month = inputDate.slice(4, 6);
-        const day = inputDate.slice(6, 8);
-        const hours = inputDate.slice(9, 11);
-        const minutes = inputDate.slice(11, 13);
-        const seconds = inputDate.slice(13, 15);
-
-        if (day < 1 || day > 31) {
-            throw new Error('Invalid day value');
-        }
-
-        if (hours < 0 || hours > 23) {
-            throw new Error('Invalid hours value');
-        }
-
-        if (minutes < 0 || minutes > 59) {
-            throw new Error('Invalid minutes value');
-        }
-
-        if (seconds < 0 || seconds > 59) {
-            throw new Error('Invalid seconds value');
-        }
-        const date = new Date(year, month - 1, day, hours, minutes, seconds);
-
-        const dayFormatted = date.getDate().toString().padStart(2, '0');
-        const monthFormatted = new Intl.DateTimeFormat('en-US', { month: 'short' }).format(date);
-        const yearFormatted = date.getFullYear().toString().slice(2);
-        const hoursFormatted = date.getHours().toString().padStart(2, '0');
-        const minutesFormatted = date.getMinutes().toString().padStart(2, '0');
-        return `${dayFormatted} ${monthFormatted} ${yearFormatted} ${hoursFormatted}:${minutesFormatted}`;
+        const result = await chrome.runtime.sendMessagePromise({
+            command: cs.command.RUN_BUILD,
+            buildType: BuildType,
+            pull
+        });
+        const queuedState = result?.response?.data?.state || result?.response?.data?.build?.state;
+        setRunButtonState(button, queuedState === "queued" ? "queued" : "starting");
+        setTimeout(() => cs.render(), 1000);
     } catch (error) {
-        console.error(error);
-        return inputDate;
+        console.error("TeamCity build start failed:", error);
+        button.disabled = false;
+        setRunButtonState(button, "retry");
     }
-}
-
-function checkStatus(response) {
-    if (response.count === 0) {
-        return cs.resultStatus.NOTBUILDS;
-    }
-
-    const { status, state } = response.build[0];
-
-    switch (true) {
-        case (status === "SUCCESS" && state === "finished"):
-            return cs.resultStatus.SUCCESS;
-        case (status === "SUCCESS" && state === "running"):
-            return cs.resultStatus.RUNNING
-        case (state === "queued"):
-            return cs.resultStatus.QUEUED;
-        case (status === "FAILURE"):
-            return cs.resultStatus.FAILURE;
-        default:
-            throw new Error(`Unknown status: ${status} or state: ${state}`);
-    }
-}
-
-function extractVersionNumber(string) {
-    if (!string) {
-        return null;
-    }
-    const match = string.match(/(\d+\.\d+\.\d+)/);
-    return match ? match[0] : null;
 }
 
 chrome.runtime.sendMessagePromise = function (message) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "TeamCity Pull Request Builder",
-    "version": "2.2.4",
+    "version": "3.0.0",
     "description": "With a plugin, you can automatically trigger builds of your project that are associated with a specific pull-request.",
     "host_permissions": [
         "*://*.ci.pravo.tech/"
@@ -27,7 +27,11 @@
                 "*://*.gitlab.pravo.tech/*"
             ],
             "js": [
+                "tc-utils.js",
                 "contentScript.js"
+            ],
+            "css": [
+                "content-style.css"
             ],
             "run_at": "document_end"
         }

--- a/options-style.css
+++ b/options-style.css
@@ -1,0 +1,383 @@
+* {
+    box-sizing: border-box;
+}
+
+body {
+    background: #f7f7f8;
+    color: #333238;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    margin: 0;
+}
+
+button,
+input,
+textarea {
+    font: inherit;
+}
+
+.settings-shell {
+    margin: 0 auto;
+    max-width: 1120px;
+    padding: 28px;
+}
+
+.settings-header {
+    align-items: center;
+    display: flex;
+    gap: 16px;
+    justify-content: space-between;
+    margin-bottom: 14px;
+}
+
+.brand {
+    align-items: center;
+    display: flex;
+    gap: 12px;
+    min-width: 0;
+}
+
+.brand-icon {
+    height: 24px;
+    width: 24px;
+}
+
+h1,
+h2,
+p {
+    margin: 0;
+}
+
+h1 {
+    font-size: 20px;
+    font-weight: 650;
+    line-height: 26px;
+}
+
+.brand p {
+    color: #737278;
+    font-size: 13px;
+    line-height: 18px;
+}
+
+.header-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.button {
+    align-items: center;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    cursor: pointer;
+    display: inline-flex;
+    font-size: 13px;
+    font-weight: 600;
+    height: 34px;
+    justify-content: center;
+    line-height: 18px;
+    padding: 0 12px;
+    white-space: nowrap;
+}
+
+.button-primary {
+    background: #1f75cb;
+    border-color: #1f75cb;
+    color: #fff;
+}
+
+.button-primary:hover {
+    background: #1068bf;
+    border-color: #1068bf;
+}
+
+.button-secondary {
+    background: #fff;
+    border-color: #dcdcde;
+    color: #333238;
+}
+
+.button-secondary:hover {
+    background: #f7f7f8;
+    border-color: #bfbfc3;
+}
+
+.button-danger {
+    background: transparent;
+    color: #c91c00;
+}
+
+.button-danger:hover {
+    background: #fbe9eb;
+}
+
+.button:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+    border-color: #1f75cb;
+    box-shadow: 0 0 0 2px rgba(31, 117, 203, .18);
+    outline: none;
+}
+
+.status-row {
+    min-height: 28px;
+}
+
+.status-message {
+    border-radius: 6px;
+    color: #737278;
+    display: inline-flex;
+    font-size: 13px;
+    line-height: 18px;
+    padding: 5px 8px;
+}
+
+.status-message.is-success {
+    background: #ecf4ee;
+    color: #217645;
+}
+
+.status-message.is-danger {
+    background: #fbe9eb;
+    color: #c91c00;
+}
+
+.settings-surface {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-radius: 8px;
+    min-height: 620px;
+}
+
+.tabs {
+    border-bottom: 1px solid #dcdcde;
+    display: flex;
+    padding: 0 16px;
+}
+
+.tab-button {
+    background: transparent;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    color: #535158;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 600;
+    height: 44px;
+    padding: 0 12px;
+}
+
+.tab-button:hover {
+    color: #1f75cb;
+}
+
+.tab-button.is-active {
+    border-bottom-color: #1f75cb;
+    color: #1f75cb;
+}
+
+.tab-panel {
+    padding: 20px;
+}
+
+.form-section + .form-section {
+    border-top: 1px solid #ececef;
+    margin-top: 22px;
+    padding-top: 20px;
+}
+
+.section-heading {
+    margin-bottom: 12px;
+}
+
+.section-heading-row {
+    align-items: center;
+    display: flex;
+    gap: 12px;
+    justify-content: space-between;
+}
+
+h2 {
+    font-size: 15px;
+    font-weight: 650;
+    line-height: 22px;
+}
+
+.connection-grid {
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+}
+
+.field span,
+.toggle-field {
+    color: #535158;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 16px;
+}
+
+input,
+textarea {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-radius: 6px;
+    color: #333238;
+    font-size: 13px;
+}
+
+input {
+    height: 34px;
+    padding: 0 10px;
+    width: 100%;
+}
+
+.toggle-field {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+    grid-column: 1 / -1;
+}
+
+.toggle-field input {
+    height: 16px;
+    width: 16px;
+}
+
+.repository-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.repo-item {
+    border: 1px solid #dcdcde;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.repo-header {
+    align-items: end;
+    background: #fafafa;
+    border-bottom: 1px solid #ececef;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: minmax(180px, 1fr) auto;
+    padding: 12px;
+}
+
+.repo-name {
+    font-weight: 600;
+}
+
+.repo-actions {
+    align-items: end;
+    align-self: end;
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.repo-actions .button {
+    height: 34px;
+}
+
+.repo-actions .button-danger {
+    background: #fff;
+    border-color: #dcdcde;
+    color: #c91c00;
+}
+
+.repo-actions .button-danger:hover {
+    background: #fbe9eb;
+    border-color: #f2b4bb;
+}
+
+.builds-container {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+}
+
+.build-item {
+    align-items: end;
+    background: #fff;
+    border: 1px solid #ececef;
+    border-radius: 6px;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: minmax(180px, 1.2fr) minmax(160px, 1fr) minmax(110px, .7fr) 76px minmax(120px, .8fr) minmax(120px, .8fr) 34px;
+    padding: 10px;
+}
+
+.icon-button {
+    align-items: center;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    color: #737278;
+    cursor: pointer;
+    display: inline-flex;
+    height: 34px;
+    justify-content: center;
+    padding: 0;
+    width: 34px;
+}
+
+.icon-button:hover {
+    background: #fbe9eb;
+    color: #c91c00;
+}
+
+.icon-button svg {
+    fill: currentColor;
+    height: 15px;
+    width: 15px;
+}
+
+#optionsJson {
+    font-family: "Cascadia Mono", "Consolas", monospace;
+    min-height: 560px;
+    padding: 14px;
+    resize: vertical;
+    width: 100%;
+}
+
+@media (max-width: 900px) {
+    .settings-shell {
+        padding: 18px;
+    }
+
+    .settings-header,
+    .section-heading-row {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .header-actions {
+        justify-content: flex-start;
+    }
+
+    .connection-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .build-item {
+        grid-template-columns: 1fr;
+    }
+
+    .repo-header {
+        grid-template-columns: 1fr;
+    }
+
+    .repo-actions {
+        justify-content: flex-start;
+    }
+}

--- a/options.html
+++ b/options.html
@@ -2,147 +2,82 @@
 <html>
 
 <head>
-    <title>Options</title>
+    <title>TeamCity Builder Options</title>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
-    <link rel="stylesheet" href="bulma.min.css" />
-    <style>
-        .content .highlight:not(:first-child) {
-            margin-top: 1em;
-        }
-
-        .content .highlight {
-            margin-left: 0;
-            margin-right: 0;
-            text-align: left;
-        }
-
-        .highlight pre {
-            background-color: transparent;
-            color: currentColor;
-            font-size: 1em;
-            line-height: 1.375;
-            margin: 0 !important;
-            padding: 1.25em 1.5em;
-            white-space: pre;
-            word-break: break-word;
-            display: flex;
-        }
-
-        .highlight {
-            background-color: #1f2330;
-            border-radius: 6px;
-            color: #d9e0e8;
-            font-size: .75em;
-            position: relative;
-        }
-    </style>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="options-style.css">
 </head>
 
-<body class="layout-documentation page-helpers">
-    <div class="bd-docs bd-is-contained">
-        <main class="bd-docs-main">
-            <div class="container">
-                <section class="hero">
-                    <div class="hero-body">
-                        <p class="title">TeamCity Pull Request Builder</p>
-                        <p class="subtitle">Options</p>
-                        <div class="columns">
-                            <div class="column is-three-fifths">
-                                <textarea class="textarea" placeholder="Json options" rows="16"
-                                    id="optionsJson"></textarea>
-                            </div>
-                        </div>
-                        <div id="notification"></div>
-                        <div class="columns">
-                            <div class="column is-three-fifths">
-                                <button class="button is-success" id="saveJson">Save</button>
-                                <button class="button is-info" id="prettifyJson">Prettify Json</button>
-                                <button class="button" id="setDefault">Set Default</button>
-                                <button class="button js-modal-trigger" data-target="modal-help">
-                                    Help
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </section>
-            </div>
-        </main>
-    </div>
-    <div id="modal-help" class="modal">
-        <div class="modal-background"></div>
-        <div class="modal-content">
-            <div class="content box">
-                <h1>Configuration Parameters:</h1>
-                <ul>
-                    <li><code>BaseUrl</code>: (Required) The URL of your TeamCity server. Example:
-                        <code>https://yourteamcityserver.com/</code>.
-                    </li>
-                    <li><code>Username</code>: (Required) The username for your TeamCity server.</li>
-                    <li><code>Password</code>: (Required) The password for your TeamCity server.</li>
-                    <li><code>Repository</code>: (Required) An object where each property represents a repository, and
-                        the value is an array of build configuration objects. Replace <code>"MyRepo"</code> with the
-                        name of your
-                        repository.</li>
-                    <li><code>BuildType</code>: (Required) The identifier of the build type in TeamCity.</li>
-                    <li><code>Name</code>: (Required) The name that will be displayed in the plugin interface.</li>
-                    <li><code>Group</code>: (Optional) The group to which this build configuration belongs. If
-                        specified, the build configurations will be grouped under this name in the plugin interface.
-                    </li>
-                    <li><code>Order</code>: (Optional) The sequential number to determine the display order of the build
-                        configurations within a group.</li>
-                    <li><code>BranchPrefix</code>: (Optional) A prefix for the branch name used in build configurations.
-                        Default value: "requests".</li>
-                    <li><code>Depends</code>: (Optional) An optional identifier of another build type that this
-                        configuration depends on. If specified, this build configuration is considered outdated or not
-                        actual if the build it depends on has a different version.</li>
-                    <li>
-                        <code>HeadingBorder</code>: (Optional) Boolean value.
-                        If set to <code>true</code>, all headings (<code>h1</code>–<code>h6</code>) in the Merge Request
-                        description
-                        will be styled with a bottom border, padding, and increased font size for better readability.
-                        Default value: <code>false</code>.
-                    </li>
-
-                </ul>
-                <div class="content">
-                    <figure class="highlight">
-                        <pre>
-                            <code class="language-markdown" data-lang="markdown">BaseUrl (Required)
-Username (Required)
-Password (Required)
-Repository (Required)
-│
-└── "MyRepo" (Your repository name)
-    ├── [0]
-    │   ├── BuildType (Required)
-    │   ├── Name (Required)
-    │   ├── Group (Optional)
-    │   └── Order (Optional)
-    │   └── BranchPrefix (Optional)
-    │   └── Depends (Optional)
-    │
-    ├── [1]
-    │   ├── BuildType (Required)
-    │   ├── Name (Required)
-    │   ├── Group (Optional)
-    │   └── Order (Optional)
-    │   └── BranchPrefix (Optional)
-    │   └── Depends (Optional)
-    │
-    ├── [2]...           
-    │
-    └── HeadingBorder (Optional)
-        └── true / false
-                            </code>
-                        </pre>
-                    </figure>
+<body>
+    <main class="settings-shell">
+        <header class="settings-header">
+            <div class="brand">
+                <img src="assets/icons/icon24.png" alt="" class="brand-icon">
+                <div>
+                    <h1>TeamCity Pull Request Builder</h1>
+                    <p>Options</p>
                 </div>
             </div>
+            <div class="header-actions">
+                <button class="button button-secondary" id="setDefault" type="button">Load example</button>
+                <button class="button button-primary" id="saveConfig" type="button">Save</button>
+            </div>
+        </header>
+
+        <div class="status-row">
+            <div id="statusMessage" class="status-message" role="status"></div>
         </div>
-        <button class="modal-close is-large" aria-label="close"></button>
-    </div>
+
+        <section class="settings-surface">
+            <div class="tabs" role="tablist" aria-label="Options editor mode">
+                <button class="tab-button is-active" id="tabUi" type="button" role="tab" aria-selected="true"
+                    aria-controls="uiPanel">UI settings</button>
+                <button class="tab-button" id="tabJson" type="button" role="tab" aria-selected="false"
+                    aria-controls="jsonPanel">Raw JSON</button>
+            </div>
+
+            <section id="uiPanel" class="tab-panel is-active" role="tabpanel" aria-labelledby="tabUi">
+                <form id="configForm">
+                    <section class="form-section">
+                        <div class="section-heading">
+                            <h2>Connection</h2>
+                        </div>
+                        <div class="connection-grid">
+                            <label class="field">
+                                <span>TeamCity URL</span>
+                                <input id="optBaseUrl" type="url" placeholder="https://yourteamcityserver.com/">
+                            </label>
+                            <label class="field">
+                                <span>Username</span>
+                                <input id="optUsername" type="text" autocomplete="username">
+                            </label>
+                            <label class="field">
+                                <span>Password or token</span>
+                                <input id="optPassword" type="password" autocomplete="current-password">
+                            </label>
+                            <label class="toggle-field">
+                                <input id="optHeadingBorder" type="checkbox">
+                                <span>Heading borders in merge request description</span>
+                            </label>
+                        </div>
+                    </section>
+
+                    <section class="form-section">
+                        <div class="section-heading section-heading-row">
+                            <h2>Repositories</h2>
+                            <button class="button button-secondary" id="addRepository" type="button">Add repository</button>
+                        </div>
+                        <div id="repositoryEditor" class="repository-editor"></div>
+                    </section>
+                </form>
+            </section>
+
+            <section id="jsonPanel" class="tab-panel" role="tabpanel" aria-labelledby="tabJson" hidden>
+                <textarea id="optionsJson" spellcheck="false" aria-label="Raw JSON settings"></textarea>
+            </section>
+        </section>
+    </main>
+
     <script src="options.js"></script>
 </body>
 

--- a/options.js
+++ b/options.js
@@ -1,187 +1,442 @@
-const options = {
-    fields: ["BaseUrl", "Username", "Password", "Repository"],
-    elements: {
-        btnPrettifyJson: document.getElementById('prettifyJson'),
-        btnSaveJson: document.getElementById('saveJson'),
-        btnSetDefault: document.getElementById('setDefault'),
-        optionsJson: document.getElementById('optionsJson'),
-        notificationContainer: document.getElementById('notification'),
-    },
-    init: async () => {
-        options.elements.btnPrettifyJson.addEventListener('click', () => {
-            options.validConfig();
-        });
-        options.elements.btnSaveJson.addEventListener('click', async () => {
-            await options.saveConfig();
-        });
-        options.elements.btnSetDefault.addEventListener('click', async () => {
-            const config = await options.setDefaultConfig();
-            const formattedJSON = JSON.stringify(config, undefined, 4);
-            options.elements.optionsJson.value = formattedJSON;
-        });
-        await options.loadConfig();
-        options.help();
-    },
-    getConfig: async () => {
-        const { config } = await chrome.storage.local.get(["config"]);
-        return config;
-    },
-    loadConfig: async () => {
-        try {
-            let config = await options.getConfig();
-            if (!config) {
-                config = await options.setDefaultConfig();
-            }
-            let sortedJsonObj = {};
-            for (let i = 0; i < options.fields.length; i++) {
-                if (options.fields[i] in config) {
-                    sortedJsonObj[options.fields[i]] = config[options.fields[i]];
-                }
-            }
-            sortedJsonObj.Password = PasswordMasker.applyMask(sortedJsonObj.Password);
-            const formattedJSON = JSON.stringify(sortedJsonObj, undefined, 4);
-            options.elements.optionsJson.value = formattedJSON;
-        }
-        catch (err) {
-            options.createNotify('is-danger', 'Invalid JSON structure');
-            console.error(err);
-        }
-    },
-    saveConfig: async () => {
-        if (options.validConfig()) {
-            const currentConfig = await options.getConfig();
-            const jsonText = options.elements.optionsJson.value;
-            const newConfig = JSON.parse(jsonText);
-            newConfig.Password = PasswordMasker.unmask(newConfig.Password, currentConfig?.Password);
-            if (newConfig.BaseUrl && !newConfig.BaseUrl.endsWith("/")) {
-                newConfig.BaseUrl += "/";
-            }
-            await chrome.storage.local.set({ config: newConfig });
-            if (checkCredentialsChanged(currentConfig, newConfig)) {
-                chrome.runtime.sendMessage({ command: 'reloadConfig' });
-            }
-            options.createNotify('is-success', 'Data saved successfully');
-        }
-
-        function checkCredentialsChanged(currentSettings, newSettings) {
-            return currentSettings?.Username !== newSettings.Username ||
-                currentSettings?.Password !== newSettings.Password;
-        }
-    },
-    setDefaultConfig: async () => {
-        const defaultConfig = {
-            "BaseUrl": "https://yourteamcityserver.com/",
-            "Username": "MyLogin",
-            "Password": "MyPassword",
-            "Repository": {
-                "MyRepo": [
-                    {
-                        "BuildType": "Tests_0",
-                        "Name": "tests 0"
-                    },
-                    {
-                        "BuildType": "Tests_1",
-                        "Name": "tests 1"
-                    }
-                ]
-            }
-        };
-        return defaultConfig;
-    },
-    validConfig: () => {
-        try {
-            const jsonText = options.elements.optionsJson.value;
-            const parsedJSON = JSON.parse(jsonText);
-            for (const field of options.fields) {
-                if (!(field in parsedJSON)) {
-                    options.createNotify('is-danger', `Missing required field: ${field}`);
-                    return false;
-                }
-            }
-            const formattedJSON = JSON.stringify(parsedJSON, null, 4);
-            options.elements.optionsJson.value = formattedJSON;
-            options.createNotify('is-success', 'Valid JSON structure');
-            return true;
-        } catch {
-            options.createNotify('is-danger', 'Invalid JSON structure');
-            return false;
-        }
-    },
-    createNotify: (style, message) => {
-        options.elements.notificationContainer.innerHTML = '';
-        const columns = document.createElement('div');
-        columns.className = 'columns';
-        const column = document.createElement('div');
-        column.className = 'column is-three-fifths';
-        const notification = document.createElement('div');
-        notification.className = `notification ${style} is-light`;
-        const deleteButton = document.createElement('button');
-        deleteButton.className = 'delete';
-        deleteButton.addEventListener('click', () => {
-            options.elements.notificationContainer.removeChild(columns);
-        });
-        const messageText = document.createTextNode(message);
-        notification.appendChild(deleteButton);
-        notification.appendChild(messageText);
-        column.appendChild(notification);
-        columns.appendChild(column);
-        options.elements.notificationContainer.appendChild(columns);
-    },
-    help: () => {
-        document.addEventListener('DOMContentLoaded', () => {
-            function openModal($el) {
-                $el.classList.add('is-active');
-            }
-
-            function closeModal($el) {
-                $el.classList.remove('is-active');
-            }
-
-            function closeAllModals() {
-                (document.querySelectorAll('.modal') || []).forEach(($modal) => {
-                    closeModal($modal);
-                });
-            }
-
-            (document.querySelectorAll('.js-modal-trigger') || []).forEach(($trigger) => {
-                const modal = $trigger.dataset.target;
-                const $target = document.getElementById(modal);
-                $trigger.addEventListener('click', () => {
-                    openModal($target);
-                });
-            });
-
-            (document.querySelectorAll('.modal-background, .modal-close, .modal-card-head .delete, .modal-card-foot .button') || []).forEach(($close) => {
-                const $target = $close.closest('.modal');
-                $close.addEventListener('click', () => {
-                    closeModal($target);
-                });
-            });
-
-            document.addEventListener('keydown', (event) => {
-                const e = event || window.event;
-                if (e.keyCode === 27) {
-                    closeAllModals();
-                }
-            });
-        });
-    }
-};
-
 const PasswordMasker = {
     mask: "********",
 
-    isMasked: function (password) {
+    isMasked(password) {
         return password === this.mask;
     },
 
-    applyMask: function () {
-        return this.mask;
+    applyMask(password) {
+        return password ? this.mask : "";
     },
 
-    unmask: function (current, original = "") {
+    unmask(current, original = "") {
         return this.isMasked(current) ? original : current;
     }
 };
 
-options.init();
+const state = {
+    config: null,
+    originalPassword: "",
+    isRendering: false,
+    activeTab: "ui"
+};
+
+const elements = {
+    save: document.getElementById("saveConfig"),
+    setDefault: document.getElementById("setDefault"),
+    status: document.getElementById("statusMessage"),
+    tabUi: document.getElementById("tabUi"),
+    tabJson: document.getElementById("tabJson"),
+    uiPanel: document.getElementById("uiPanel"),
+    jsonPanel: document.getElementById("jsonPanel"),
+    form: document.getElementById("configForm"),
+    addRepository: document.getElementById("addRepository"),
+    repositoryEditor: document.getElementById("repositoryEditor"),
+    json: document.getElementById("optionsJson"),
+    baseUrl: document.getElementById("optBaseUrl"),
+    username: document.getElementById("optUsername"),
+    password: document.getElementById("optPassword"),
+    headingBorder: document.getElementById("optHeadingBorder")
+};
+
+const requiredFields = ["BaseUrl", "Username", "Password", "Repository"];
+
+async function init() {
+    elements.save.addEventListener("click", saveConfig);
+    elements.setDefault.addEventListener("click", loadExample);
+    elements.addRepository.addEventListener("click", () => {
+        addRepositoryElement("MyRepo", []);
+        syncFromUi("Repository added");
+    });
+    elements.form.addEventListener("input", () => syncFromUi());
+    elements.form.addEventListener("change", () => syncFromUi());
+    elements.json.addEventListener("input", syncFromJson);
+    elements.tabUi.addEventListener("click", () => setActiveTab("ui"));
+    elements.tabJson.addEventListener("click", () => setActiveTab("json"));
+
+    const config = await getStoredConfig() || getDefaultConfig();
+    state.originalPassword = config.Password || "";
+    renderAll(config);
+    setStatus("Ready", "muted");
+}
+
+async function getStoredConfig() {
+    const { config } = await chrome.storage.local.get(["config"]);
+    return config;
+}
+
+function getDefaultConfig() {
+    return {
+        BaseUrl: "https://yourteamcityserver.com/",
+        Username: "MyLogin",
+        Password: "MyPassword",
+        Repository: {
+            MyRepo: [
+                {
+                    BuildType: "Build_Type",
+                    Name: "Build"
+                },
+                {
+                    BuildType: "Tests_0",
+                    Name: "Tests 0",
+                    Group: "Tests",
+                    Order: 1,
+                    Depends: "Build_Type"
+                }
+            ]
+        }
+    };
+}
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+function toDisplayConfig(config) {
+    const displayConfig = {
+        BaseUrl: config.BaseUrl || "",
+        Username: config.Username || "",
+        Password: PasswordMasker.applyMask(config.Password),
+        Repository: config.Repository || {}
+    };
+
+    if (config.HeadingBorder === true) {
+        displayConfig.HeadingBorder = true;
+    }
+
+    return displayConfig;
+}
+
+function normalizeConfig(config) {
+    const normalized = {
+        BaseUrl: config.BaseUrl || "",
+        Username: config.Username || "",
+        Password: config.Password || "",
+        Repository: config.Repository || {}
+    };
+
+    if (config.HeadingBorder === true) {
+        normalized.HeadingBorder = true;
+    }
+
+    return normalized;
+}
+
+function renderAll(config) {
+    state.isRendering = true;
+    state.config = normalizeConfig(clone(config));
+    renderForm(state.config);
+    renderJson(state.config);
+    state.isRendering = false;
+}
+
+function renderForm(config) {
+    const displayConfig = toDisplayConfig(config);
+    elements.baseUrl.value = displayConfig.BaseUrl;
+    elements.username.value = displayConfig.Username;
+    elements.password.value = displayConfig.Password;
+    elements.headingBorder.checked = displayConfig.HeadingBorder === true;
+    elements.repositoryEditor.replaceChildren();
+
+    Object.entries(displayConfig.Repository).forEach(([repoName, builds]) => {
+        addRepositoryElement(repoName, builds);
+    });
+}
+
+function renderJson(config) {
+    elements.json.value = JSON.stringify(toDisplayConfig(config), null, 4);
+}
+
+function setActiveTab(tab) {
+    state.activeTab = tab;
+    const isUi = tab === "ui";
+    elements.tabUi.classList.toggle("is-active", isUi);
+    elements.tabJson.classList.toggle("is-active", !isUi);
+    elements.tabUi.setAttribute("aria-selected", String(isUi));
+    elements.tabJson.setAttribute("aria-selected", String(!isUi));
+    elements.uiPanel.hidden = !isUi;
+    elements.jsonPanel.hidden = isUi;
+    elements.uiPanel.classList.toggle("is-active", isUi);
+    elements.jsonPanel.classList.toggle("is-active", !isUi);
+}
+
+function syncFromUi(message = "Synced") {
+    if (state.isRendering) {
+        return;
+    }
+
+    state.config = collectConfigFromForm();
+    state.isRendering = true;
+    renderJson(state.config);
+    state.isRendering = false;
+    setStatus(message, "muted");
+}
+
+function syncFromJson() {
+    if (state.isRendering) {
+        return;
+    }
+
+    try {
+        const parsed = JSON.parse(elements.json.value);
+        const validation = validateConfig(parsed);
+        if (!validation.ok) {
+            setStatus(validation.message, "danger");
+            return;
+        }
+
+        state.config = normalizeConfig(parsed);
+        state.isRendering = true;
+        renderForm(state.config);
+        state.isRendering = false;
+        setStatus("JSON synced", "muted");
+    } catch {
+        setStatus("JSON is not valid", "danger");
+    }
+}
+
+function collectConfigFromForm() {
+    const repository = {};
+    elements.repositoryEditor.querySelectorAll(".repo-item").forEach(repoItem => {
+        const repoName = repoItem.querySelector(".repo-name").value.trim();
+        if (!repoName) {
+            return;
+        }
+
+        repository[repoName] = [];
+        repoItem.querySelectorAll(".build-item").forEach(buildItem => {
+            const build = {};
+            const buildType = buildItem.querySelector(".build-type").value.trim();
+            const name = buildItem.querySelector(".build-name").value.trim();
+            const group = buildItem.querySelector(".build-group").value.trim();
+            const order = buildItem.querySelector(".build-order").value;
+            const branchPrefix = buildItem.querySelector(".build-branch-prefix").value.trim();
+            const depends = buildItem.querySelector(".build-depends").value.trim();
+
+            if (buildType) {
+                build.BuildType = buildType;
+            }
+            if (name) {
+                build.Name = name;
+            }
+            if (group) {
+                build.Group = group;
+            }
+            if (order !== "") {
+                build.Order = Number(order);
+            }
+            if (branchPrefix) {
+                build.BranchPrefix = branchPrefix;
+            }
+            if (depends) {
+                build.Depends = depends;
+            }
+
+            repository[repoName].push(build);
+        });
+    });
+
+    const config = {
+        BaseUrl: elements.baseUrl.value.trim(),
+        Username: elements.username.value.trim(),
+        Password: elements.password.value,
+        Repository: repository
+    };
+
+    if (elements.headingBorder.checked) {
+        config.HeadingBorder = true;
+    }
+
+    return config;
+}
+
+function validateConfig(config) {
+    if (!config || typeof config !== "object" || Array.isArray(config)) {
+        return { ok: false, message: "Config must be an object" };
+    }
+
+    for (const field of requiredFields) {
+        if (!(field in config)) {
+            return { ok: false, message: `Missing required field: ${field}` };
+        }
+    }
+
+    if (!config.Repository || typeof config.Repository !== "object" || Array.isArray(config.Repository)) {
+        return { ok: false, message: "Repository must be an object" };
+    }
+
+    for (const [repoName, builds] of Object.entries(config.Repository)) {
+        if (!repoName || !Array.isArray(builds)) {
+            return { ok: false, message: "Each repository must contain a build array" };
+        }
+        for (const build of builds) {
+            if (!build || typeof build !== "object" || !build.BuildType || !build.Name) {
+                return { ok: false, message: "Each build must contain BuildType and Name" };
+            }
+        }
+    }
+
+    return { ok: true, message: "" };
+}
+
+async function saveConfig() {
+    const config = state.activeTab === "json" ? parseJsonForSave() : collectConfigFromForm();
+    if (!config) {
+        return;
+    }
+
+    const validation = validateConfig(config);
+    if (!validation.ok) {
+        setStatus(validation.message, "danger");
+        return;
+    }
+
+    const currentConfig = await getStoredConfig();
+    const newConfig = normalizeConfig(config);
+    newConfig.Password = PasswordMasker.unmask(newConfig.Password, state.originalPassword || currentConfig?.Password);
+    if (newConfig.BaseUrl && !newConfig.BaseUrl.endsWith("/")) {
+        newConfig.BaseUrl += "/";
+    }
+
+    await chrome.storage.local.set({ config: newConfig });
+    state.originalPassword = newConfig.Password || "";
+
+    if (currentConfig?.Username !== newConfig.Username || currentConfig?.Password !== newConfig.Password) {
+        chrome.runtime.sendMessage({ command: "reloadConfig" });
+    }
+
+    renderAll(newConfig);
+    setStatus("Saved", "success");
+}
+
+function parseJsonForSave() {
+    try {
+        return JSON.parse(elements.json.value);
+    } catch {
+        setStatus("JSON is not valid", "danger");
+        return null;
+    }
+}
+
+function loadExample() {
+    const config = getDefaultConfig();
+    state.originalPassword = config.Password;
+    renderAll(config);
+    setStatus("Example loaded", "muted");
+}
+
+function addRepositoryElement(repoName, builds) {
+    const repoItem = document.createElement("section");
+    repoItem.className = "repo-item";
+
+    const header = document.createElement("div");
+    header.className = "repo-header";
+
+    const repoNameField = createField("Repository", "repo-name", repoName || "");
+    header.appendChild(repoNameField);
+
+    const actions = document.createElement("div");
+    actions.className = "repo-actions";
+
+    const addBuild = document.createElement("button");
+    addBuild.type = "button";
+    addBuild.className = "button button-secondary";
+    addBuild.textContent = "Add build";
+    actions.appendChild(addBuild);
+
+    const removeRepo = document.createElement("button");
+    removeRepo.type = "button";
+    removeRepo.className = "button button-danger";
+    removeRepo.textContent = "Remove";
+    actions.appendChild(removeRepo);
+    header.appendChild(actions);
+
+    const buildsContainer = document.createElement("div");
+    buildsContainer.className = "builds-container";
+
+    addBuild.addEventListener("click", () => {
+        addBuildElement(buildsContainer, {});
+        syncFromUi("Build added");
+    });
+    removeRepo.addEventListener("click", () => {
+        repoItem.remove();
+        syncFromUi("Repository removed");
+    });
+
+    repoItem.appendChild(header);
+    repoItem.appendChild(buildsContainer);
+    elements.repositoryEditor.appendChild(repoItem);
+
+    const buildList = Array.isArray(builds) ? builds : [];
+    if (buildList.length === 0) {
+        addBuildElement(buildsContainer, {});
+    } else {
+        buildList.forEach(build => addBuildElement(buildsContainer, build));
+    }
+}
+
+function addBuildElement(container, build) {
+    const buildItem = document.createElement("div");
+    buildItem.className = "build-item";
+
+    buildItem.appendChild(createField("Build type", "build-type", build.BuildType || ""));
+    buildItem.appendChild(createField("Name", "build-name", build.Name || ""));
+    buildItem.appendChild(createField("Group", "build-group", build.Group || ""));
+    buildItem.appendChild(createField("Order", "build-order", build.Order ?? "", "number"));
+    buildItem.appendChild(createField("Branch prefix", "build-branch-prefix", build.BranchPrefix || ""));
+    buildItem.appendChild(createField("Depends", "build-depends", build.Depends || ""));
+
+    const remove = document.createElement("button");
+    remove.type = "button";
+    remove.className = "icon-button";
+    remove.title = "Remove build";
+    remove.setAttribute("aria-label", "Remove build");
+    remove.appendChild(createTrashIcon());
+    remove.addEventListener("click", () => {
+        buildItem.remove();
+        syncFromUi("Build removed");
+    });
+    buildItem.appendChild(remove);
+
+    container.appendChild(buildItem);
+}
+
+function createField(label, className, value, type = "text") {
+    const field = document.createElement("label");
+    field.className = "field";
+
+    const labelElement = document.createElement("span");
+    labelElement.textContent = label;
+
+    const input = document.createElement("input");
+    input.className = className;
+    input.type = type;
+    input.value = value;
+
+    field.appendChild(labelElement);
+    field.appendChild(input);
+    return field;
+}
+
+function createTrashIcon() {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("viewBox", "0 0 16 16");
+    svg.setAttribute("aria-hidden", "true");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", "M6.5 1.75A.75.75 0 0 1 7.25 1h1.5a.75.75 0 0 1 .75.75V2.5H13a.75.75 0 0 1 0 1.5h-.55l-.62 9.3A1.75 1.75 0 0 1 10.08 15H5.92a1.75 1.75 0 0 1-1.75-1.7L3.55 4H3a.75.75 0 0 1 0-1.5h3.5v-.75ZM5.05 4l.62 9.2a.25.25 0 0 0 .25.3h4.16a.25.25 0 0 0 .25-.3L10.95 4h-5.9Z");
+    svg.appendChild(path);
+    return svg;
+}
+
+function setStatus(message, type) {
+    elements.status.className = "status-message";
+    if (type === "success") {
+        elements.status.classList.add("is-success");
+    }
+    if (type === "danger") {
+        elements.status.classList.add("is-danger");
+    }
+    elements.status.textContent = message;
+}
+
+init();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
-  "name": "git",
-  "version": "1.0.0",
+  "name": "teamcity-pull-request-builder",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "git",
-      "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "chrome-extension-async": "^3.4.1"
-      }
+      "name": "teamcity-pull-request-builder",
+      "version": "3.0.0",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "git",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "name": "teamcity-pull-request-builder",
+  "version": "3.0.0",
+  "description": "Chrome extension for running TeamCity builds from pull requests.",
+  "main": "tc-utils.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "check": "node --check background.js && node --check contentScript.js && node --check options.js && node --check popup.js && node --check tc-utils.js",
+    "test": "npm run check && node tests/tc-utils.test.js"
   },
   "author": "",
-  "license": "ISC"
+  "license": "Apache-2.0"
 }

--- a/popup.html
+++ b/popup.html
@@ -1,27 +1,36 @@
 <!DOCTYPE html>
-<html class="is-size-7">
+<html>
 
 <head>
     <title>TeamCity Builder</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <link rel="stylesheet" href="style.css" />
-    <link rel="stylesheet" href="bulma.min.css" />
 </head>
 
 <body>
-    <div class="card">
-        <div class="card-content">
-            <p class="title is-4">TeamCity Pull Request Builder</p>
-            <p class="subtitle pt-4">
-                <button class="button is-outlined" id="settings-btn">Options</button>
-            </p>
+    <main class="popup-shell">
+        <div class="popup-header">
+            <img src="assets/icons/icon24.png" alt="" class="popup-icon">
+            <div>
+                <h1>TeamCity Builder</h1>
+                <p id="version-label"></p>
+            </div>
         </div>
-        <footer class="card-footer">
-            <p class="card-footer-item is-justify-content-space-between px-2" id="summary"></p>
+
+        <button class="primary-action" id="settings-btn" type="button">
+            <span>Open options</span>
+            <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M8 2.75a.75.75 0 0 1 .75.75v1.08a4.02 4.02 0 0 1 1.02.43l.76-.76a.75.75 0 1 1 1.06 1.06l-.76.76c.19.32.33.66.43 1.02h1.08a.75.75 0 0 1 0 1.5h-1.08a4.02 4.02 0 0 1-.43 1.02l.76.76a.75.75 0 1 1-1.06 1.06l-.76-.76c-.32.19-.66.33-1.02.43v1.08a.75.75 0 0 1-1.5 0v-1.08a4.02 4.02 0 0 1-1.02-.43l-.76.76a.75.75 0 1 1-1.06-1.06l.76-.76a4.02 4.02 0 0 1-.43-1.02H3.66a.75.75 0 0 1 0-1.5h1.08c.1-.36.24-.7.43-1.02l-.76-.76A.75.75 0 1 1 5.47 4.25l.76.76c.32-.19.66-.33 1.02-.43V3.5A.75.75 0 0 1 8 2.75ZM8 6a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"></path>
+            </svg>
+        </button>
+
+        <footer class="popup-footer">
+            <a id="github-link" href="https://github.com/deimosowen/TeamCity-Pull-Request-Builder" target="_blank"
+                rel="noopener noreferrer">GitHub</a>
+            <a id="release-link" target="_blank" rel="noopener noreferrer">Release notes</a>
         </footer>
-    </div>
+    </main>
     <script src="popup.js"></script>
 </body>
 

--- a/popup.js
+++ b/popup.js
@@ -1,22 +1,8 @@
 const version = chrome.runtime.getManifest().version;
-const formGroup = document.querySelector('.form-group');
-const summary = document.getElementById('summary');
 
-const linkElem = document.createElement('a');
-linkElem.href = 'https://github.com/deimosowen/TeamCity-Pull-Request-Builder';
-linkElem.innerHTML = '<span>GitHub Repository</span>';
-linkElem.target = '_blank';
-linkElem.classList.add('button', 'is-ghost');
-summary.appendChild(linkElem);
+document.getElementById("version-label").textContent = `Version ${version}`;
+document.getElementById("release-link").href = `https://github.com/deimosowen/TeamCity-Pull-Request-Builder/releases/tag/${version}`;
 
-const versionElem = document.createElement('a');
-versionElem.href = `https://github.com/deimosowen/TeamCity-Pull-Request-Builder/releases/tag/${version}`;
-versionElem.innerText = `Version: ${version}`;
-versionElem.target = '_blank';
-versionElem.classList.add('button', 'is-ghost');
-versionElem.classList.add('pr-2');
-summary.appendChild(versionElem);
-
-document.getElementById('settings-btn').addEventListener('click', () => {
-    chrome.tabs.create({ url: 'options.html' });
+document.getElementById("settings-btn").addEventListener("click", () => {
+    chrome.tabs.create({ url: "options.html" });
 });

--- a/style.css
+++ b/style.css
@@ -1,14 +1,108 @@
 html {
-    width: 290px;
+    width: 300px;
 }
 
 * {
     box-sizing: border-box;
-    font-family: "Roboto", sans-serif;
 }
 
 body {
+    background: #fff;
+    color: #333238;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     margin: 0;
-    padding: 0;
-    background-color: #f5f5f5;
+}
+
+.popup-shell {
+    padding: 14px;
+}
+
+.popup-header {
+    align-items: center;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: 28px minmax(0, 1fr);
+    margin-bottom: 14px;
+}
+
+.popup-icon {
+    height: 24px;
+    width: 24px;
+}
+
+h1 {
+    color: #333238;
+    font-size: 15px;
+    font-weight: 650;
+    line-height: 20px;
+    margin: 0;
+}
+
+#version-label {
+    color: #737278;
+    font-size: 12px;
+    line-height: 16px;
+    margin: 1px 0 0;
+}
+
+.primary-action {
+    align-items: center;
+    background: #1f75cb;
+    border: 1px solid #1f75cb;
+    border-radius: 6px;
+    color: #fff;
+    cursor: pointer;
+    display: flex;
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    height: 36px;
+    justify-content: space-between;
+    line-height: 18px;
+    padding: 0 11px;
+    width: 100%;
+}
+
+.primary-action:hover {
+    background: #1068bf;
+    border-color: #1068bf;
+}
+
+.primary-action:focus-visible {
+    box-shadow: 0 0 0 2px rgba(31, 117, 203, .22);
+    outline: none;
+}
+
+.primary-action svg {
+    fill: currentColor;
+    height: 15px;
+    width: 15px;
+}
+
+.popup-footer {
+    align-items: center;
+    border-top: 1px solid #ececef;
+    display: flex;
+    justify-content: space-between;
+    margin-top: 14px;
+    padding-top: 10px;
+}
+
+.popup-footer a {
+    border-radius: 4px;
+    color: #535158;
+    font-size: 12px;
+    line-height: 16px;
+    padding: 3px 4px;
+    text-decoration: none;
+}
+
+.popup-footer a:hover {
+    background: #f7f7f8;
+    color: #1f75cb;
+}
+
+.popup-footer a:focus-visible {
+    box-shadow: 0 0 0 2px rgba(31, 117, 203, .18);
+    outline: none;
 }

--- a/tc-utils.js
+++ b/tc-utils.js
@@ -1,0 +1,192 @@
+(function (root, factory) {
+    const api = factory();
+    if (typeof module === "object" && module.exports) {
+        module.exports = api;
+    }
+    root.TcPrbUtils = api;
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+    const resultStatus = {
+        SUCCESS: "SUCCESS",
+        RUNNING: "RUNNING",
+        FAILURE: "FAILURE",
+        QUEUED: "QUEUED",
+        NOT_BUILDS: "NOT_BUILDS",
+        ERROR: "ERROR"
+    };
+
+    function escapeRegExp(value) {
+        return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+
+    function asArray(value) {
+        if (!value) {
+            return [];
+        }
+        return Array.isArray(value) ? value : [value];
+    }
+
+    function getBuilds(response) {
+        if (!response || !response.build) {
+            return [];
+        }
+        return asArray(response.build).filter(Boolean);
+    }
+
+    function normalizeBuildStatus(response) {
+        const builds = getBuilds(response);
+        if (!response || Number(response.count) === 0 || builds.length === 0) {
+            return {
+                status: resultStatus.NOT_BUILDS,
+                severity: "muted",
+                label: "Build not initiated yet"
+            };
+        }
+
+        const build = builds[0];
+        const status = String(build.status || "").toUpperCase();
+        const state = String(build.state || "").toLowerCase();
+        const statusText = build.statusText || build.statusTextHtml || build.comment?.text || "";
+
+        if (state === "queued") {
+            return {
+                status: resultStatus.QUEUED,
+                severity: "queued",
+                label: "Build in queue",
+                build
+            };
+        }
+
+        if (state === "running") {
+            return {
+                status: resultStatus.RUNNING,
+                severity: "running",
+                label: "Build in progress",
+                build
+            };
+        }
+
+        if (status === "SUCCESS" && state === "finished") {
+            return {
+                status: resultStatus.SUCCESS,
+                severity: "success",
+                label: "Successful",
+                build
+            };
+        }
+
+        if (status === "FAILURE" || status === "ERROR" || status === "UNKNOWN" || state === "finished") {
+            return {
+                status: resultStatus.FAILURE,
+                severity: "failure",
+                label: statusText || "Failed",
+                build
+            };
+        }
+
+        return {
+            status: resultStatus.ERROR,
+            severity: "failure",
+            label: statusText || `Unknown status: ${status || "empty"} / ${state || "empty"}`,
+            build
+        };
+    }
+
+    function parseTeamCityDate(value) {
+        if (!value || typeof value !== "string") {
+            return null;
+        }
+
+        const match = value.match(/^(\d{4})(\d{2})(\d{2})T?(\d{2})(\d{2})(\d{2})([+-]\d{4}|Z)?$/);
+        if (!match) {
+            const parsed = new Date(value);
+            return Number.isNaN(parsed.getTime()) ? null : parsed;
+        }
+
+        const [, year, month, day, hour, minute, second, zone = "Z"] = match;
+        const normalizedZone = zone === "Z" ? "Z" : `${zone.slice(0, 3)}:${zone.slice(3)}`;
+        const parsed = new Date(`${year}-${month}-${day}T${hour}:${minute}:${second}${normalizedZone}`);
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    function formatShortDate(inputDate) {
+        const date = inputDate instanceof Date ? inputDate : parseTeamCityDate(inputDate);
+        if (!date) {
+            return inputDate || "";
+        }
+
+        const dayFormatted = date.getDate().toString().padStart(2, "0");
+        const monthFormatted = new Intl.DateTimeFormat("en-US", { month: "short" }).format(date);
+        const yearFormatted = date.getFullYear().toString().slice(2);
+        const hoursFormatted = date.getHours().toString().padStart(2, "0");
+        const minutesFormatted = date.getMinutes().toString().padStart(2, "0");
+        return `${dayFormatted} ${monthFormatted} ${yearFormatted} ${hoursFormatted}:${minutesFormatted}`;
+    }
+
+    function formatDuration(ms) {
+        if (!Number.isFinite(ms) || ms < 0) {
+            return "";
+        }
+
+        const totalMinutes = Math.floor(ms / 60000);
+        const hours = Math.floor(totalMinutes / 60);
+        const minutes = totalMinutes % 60;
+
+        if (hours > 0) {
+            return `${hours}h ${minutes.toString().padStart(2, "0")}m`;
+        }
+        if (minutes > 0) {
+            return `${minutes}m`;
+        }
+        return "<1m";
+    }
+
+    function getBuildTiming(build, now = new Date()) {
+        if (!build) {
+            return {
+                dateText: "",
+                durationText: ""
+            };
+        }
+
+        const start = parseTeamCityDate(build.startDate || build.queuedDate);
+        const finish = parseTeamCityDate(build.finishOnAgentDate || build.finishDate);
+        const end = finish || now;
+        const durationText = start ? formatDuration(end.getTime() - start.getTime()) : "";
+        const dateSource = finish || start;
+
+        return {
+            dateText: dateSource ? formatShortDate(dateSource) : "",
+            durationText
+        };
+    }
+
+    function getRepoNameFromGitLabUrl(url) {
+        const match = String(url).match(/^https?:\/\/[^/]+\/(.+)\/-\/merge_requests\//);
+        if (!match) {
+            return "";
+        }
+        const parts = match[1].split("/").filter(Boolean);
+        return parts[parts.length - 1] || "";
+    }
+
+    function extractVersionNumber(value) {
+        if (!value) {
+            return null;
+        }
+        const match = String(value).match(/(\d+\.\d+\.\d+)/);
+        return match ? match[0] : null;
+    }
+
+    return {
+        resultStatus,
+        escapeRegExp,
+        getBuilds,
+        normalizeBuildStatus,
+        parseTeamCityDate,
+        formatShortDate,
+        formatDuration,
+        getBuildTiming,
+        getRepoNameFromGitLabUrl,
+        extractVersionNumber
+    };
+});

--- a/tests/tc-utils.test.js
+++ b/tests/tc-utils.test.js
@@ -1,0 +1,64 @@
+const assert = require("node:assert/strict");
+const utils = require("../tc-utils");
+
+function test(name, fn) {
+    try {
+        fn();
+        console.log(`ok - ${name}`);
+    } catch (error) {
+        console.error(`not ok - ${name}`);
+        throw error;
+    }
+}
+
+test("normalizes empty response as not built", () => {
+    const result = utils.normalizeBuildStatus({ count: 0, build: [] });
+    assert.equal(result.status, utils.resultStatus.NOT_BUILDS);
+});
+
+test("normalizes successful finished build", () => {
+    const result = utils.normalizeBuildStatus({
+        count: 1,
+        build: [{ status: "SUCCESS", state: "finished" }]
+    });
+    assert.equal(result.status, utils.resultStatus.SUCCESS);
+});
+
+test("normalizes TeamCity collect changes error as failure", () => {
+    const result = utils.normalizeBuildStatus({
+        count: 1,
+        build: [{
+            status: "UNKNOWN",
+            state: "finished",
+            statusText: "Unable to collect changes"
+        }]
+    });
+    assert.equal(result.status, utils.resultStatus.FAILURE);
+    assert.equal(result.label, "Unable to collect changes");
+});
+
+test("normalizes queued and running builds", () => {
+    assert.equal(utils.normalizeBuildStatus({ count: 1, build: [{ state: "queued" }] }).status, utils.resultStatus.QUEUED);
+    assert.equal(utils.normalizeBuildStatus({ count: 1, build: [{ status: "SUCCESS", state: "running" }] }).status, utils.resultStatus.RUNNING);
+});
+
+test("parses TeamCity date and formats duration", () => {
+    const date = utils.parseTeamCityDate("20260616T180700+0300");
+    assert.equal(date.toISOString(), "2026-06-16T15:07:00.000Z");
+    assert.equal(utils.formatDuration(65 * 60000), "1h 05m");
+    assert.equal(utils.formatDuration(59 * 1000), "<1m");
+});
+
+test("build timing uses TeamCity start and finish dates", () => {
+    const timing = utils.getBuildTiming({
+        startDate: "20260616T180700+0300",
+        finishDate: "20260616T183900+0300"
+    });
+    assert.equal(timing.durationText, "32m");
+    assert.equal(timing.dateText, "16 Jun 26 18:39");
+});
+
+test("extracts nested GitLab repository name", () => {
+    const repo = utils.getRepoNameFromGitLabUrl("https://gitlab.pravo.tech/group/subgroup/MyRepo/-/merge_requests/123");
+    assert.equal(repo, "MyRepo");
+});


### PR DESCRIPTION
## Summary
- Prepare the extension for 3.0.0 with refreshed GitLab sidebar UI, popup UI, and a redesigned synchronized Options page.
- Add TeamCity status normalization, refresh support, build duration fields, safer config handling, and focused utility tests.
- Add an automated release workflow that builds, uploads to Chrome Web Store, submits publish, and creates a GitHub release when the manifest version is new.

## Impact
- Users get clearer TeamCity build state, duration display, refresh without page reload, and friendlier settings editing.
- Maintainers get a repeatable release path after merging version changes to main.

## Validation
- `npm test`
- `git diff --check`